### PR TITLE
Accessibility features added for screen reader support

### DIFF
--- a/frontend/react/src/components/EditProfilePic.tsx
+++ b/frontend/react/src/components/EditProfilePic.tsx
@@ -1,9 +1,9 @@
 import React, { useState, useEffect, useRef } from "react";
 
 interface ProfilePicProps {
-	pic: File | null;
-	onChange: (file: File | null) => void;
-	//onSave: () => void; // optional save handler -> figure out flow for pic saving
+  pic: File | null;
+  onChange: (file: File | null) => void;
+  //onSave: () => void; // optional save handler -> figure out flow for pic saving
 }
 
 /*
@@ -13,108 +13,163 @@ won't display the erroneous filename next to Choose file button. Displays a prop
 picture file in the circle and changes will be committed only after user clicks Save.
 Allows only file types .jpg, .jpeg and .png. Max file size is limited to 2MB.
 */
-const EditProfilePic: React.FC<ProfilePicProps> = ({ pic, onChange/*, onSave */}) => {
-	const [previewUrl, setPreviewUrl] = useState<string | null>(null);
-	const [newPic, setNewPic] = useState<File | null>(null); // holds unconfirmed file
-	const [error, setError] = useState<string | null>(null);
-	const [success, setSuccess] = useState(false);
-	const fileInputRef = useRef<HTMLInputElement>(null); // to reset input
+const EditProfilePic: React.FC<ProfilePicProps> = ({
+  pic,
+  onChange /*, onSave */,
+}) => {
+  const [previewUrl, setPreviewUrl] = useState<string | null>(null);
+  const [newPic, setNewPic] = useState<File | null>(null); // holds unconfirmed file
+  const [error, setError] = useState<string | null>(null);
+  const [success, setSuccess] = useState(false);
+  const fileInputRef = useRef<HTMLInputElement>(null); // to reset input
+  const liveRegionRef = useRef<HTMLDivElement>(null);
+  const [liveMessage, setLiveMessage] = useState<string | null>(null);
 
-	const allowedTypes = ["image/jpeg", "image/png"];
-	const maxSizeMB = 2;
+  const allowedTypes = ["image/jpeg", "image/png"];
+  const maxSizeMB = 2;
 
-	// update preview URL for either existing pic or newPic
-	useEffect(() => {
-		let url: string | null = null;
+  useEffect(() => {
+    if (error || success) {
+      setLiveMessage(null); // force remount
+      setTimeout(() => {
+        setLiveMessage(error || (success ? "Picture saved!" : ""));
+        // Give React time to render it
+        setTimeout(() => {
+          liveRegionRef.current?.focus();
+        }, 10);
+      }, 100); // wait for file input focus shift to complete
+    }
+  }, [error, success]);
 
-		if (newPic) {
-			url = URL.createObjectURL(newPic);
-		} else if (pic) {
-			url = URL.createObjectURL(pic);
-		}
+  // update preview URL for either existing pic or newPic
+  useEffect(() => {
+    let url: string | null = null;
 
-		setPreviewUrl(url);
+    if (newPic) {
+      url = URL.createObjectURL(newPic);
+    } else if (pic) {
+      url = URL.createObjectURL(pic);
+    }
 
-		return () => {
-			if (url) URL.revokeObjectURL(url); // clean up
-		};
+    setPreviewUrl(url);
 
-	}, [pic, newPic]);
+    return () => {
+      if (url) URL.revokeObjectURL(url); // clean up
+    };
+  }, [pic, newPic]);
 
-	const handleFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-		const file = e.target.files?.[0];
-		if (!file) return;
+  const handleFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (!file) return;
 
-		const isValidType = allowedTypes.includes(file.type);
-		const isValidSize = file.size <= maxSizeMB * 1024 * 1024;
+    const isValidType = allowedTypes.includes(file.type);
+    const isValidSize = file.size <= maxSizeMB * 1024 * 1024;
 
-		if (!isValidType) {
-			setError("Only JPG and PNG images are allowed.");
-			setNewPic(null);
-			resetInput();
-			return;
-		}
+    if (!isValidType) {
+      setError("Only JPG and PNG images are allowed.");
+      setNewPic(null);
+      resetInput();
+      return;
+    }
 
-		if (!isValidSize) {
-			setError("File size must be less than 2MB.");
-			setNewPic(null);
-			resetInput();
-			return;
-		}
-		setError(null);
-		setNewPic(file);
-	};
+    if (!isValidSize) {
+      setError("File size must be less than 2MB.");
+      setNewPic(null);
+      resetInput();
+      return;
+    }
+    setError(null);
+    setNewPic(file);
+  };
 
-	const resetInput = () => {
-		if (fileInputRef.current) {
-			fileInputRef.current.value = "";
-		}
-	};
+  const resetInput = () => {
+    if (fileInputRef.current) {
+      fileInputRef.current.value = "";
+    }
+  };
 
-	const handleSave = () => {
-		if (newPic) {
-			onChange(newPic);
-			//onSave(); // this is undefined and hitting save will make console go red
-			setNewPic(null);
-			setSuccess(true);
-			resetInput();
-			setTimeout(() => setSuccess(false), 2000); // clears after 2s
-		}
-	};
+  const handleSave = () => {
+    if (newPic) {
+      onChange(newPic);
+      //onSave(); // this is undefined and hitting save will make console go red
+      setNewPic(null);
+      setSuccess(true);
+      resetInput();
+      setTimeout(() => setSuccess(false), 2000); // clears after 2s
+    }
+  };
 
-	return (
-		<div className="max-w-sm mx-auto block">
-			{previewUrl ? (
-				<img className="mx-auto my-3"
-					src={previewUrl}
-					alt="Profile pic"
-					style={{ width: "80px", height: "80px", objectFit: "cover", borderRadius: "50%", marginTop: "0.5rem" }}
-				/>
-			) : (
-				<div className="mx-auto" style={{ width: "80px", height: "80px", backgroundColor: "#eee", borderRadius: "50%", marginTop: "0.5rem" }} />
-			)}
-			<div>
-				<input className="block w-full m-5 text-sm text-gray-900 border border-gray-300 rounded-lg cursor-pointer bg-gray-50 dark:text-gray-400 focus:outline-none dark:bg-gray-700 dark:border-gray-600 dark:placeholder-gray-400"
-					ref={fileInputRef}
-					type="file"
-					accept="image/png, image/jpeg"
-					onChange={handleFileChange}
-				/>
-				{error && <div className="text-red-700 dark:text-red-600 mt-0.5">{error}</div>}
-				{success && <div className="text-green-700 dark:text-green-500 mt-0.5">Picture saved!</div>}
-			</div>
+  return (
+    <div className="max-w-sm mx-auto block">
+      {previewUrl ? (
+        <img
+          className="mx-auto my-3"
+          src={previewUrl}
+          alt="Profile pic"
+          style={{
+            width: "80px",
+            height: "80px",
+            objectFit: "cover",
+            borderRadius: "50%",
+            marginTop: "0.5rem",
+          }}
+        />
+      ) : (
+        <div
+          className="mx-auto"
+          style={{
+            width: "80px",
+            height: "80px",
+            backgroundColor: "#eee",
+            borderRadius: "50%",
+            marginTop: "0.5rem",
+          }}
+        />
+      )}
+      <div>
+        <input
+          className="block w-full m-5 text-sm text-gray-900 border border-gray-300 rounded-lg cursor-pointer bg-gray-50 dark:text-gray-400 focus:outline-none dark:bg-gray-700 dark:border-gray-600 dark:placeholder-gray-400"
+          ref={fileInputRef}
+          type="file"
+          accept="image/png, image/jpeg"
+          onChange={handleFileChange}
+        />
+        {error && (
+          <span className="text-red-700 dark:text-red-600 mt-0.5">{error}</span>
+        )}
+        {success && (
+          <span className="text-green-700 dark:text-green-500 mt-0.5">
+            Picture saved!
+          </span>
+        )}
+      </div>
+      {liveMessage && (
+        <div
+          ref={liveRegionRef}
+          tabIndex={-1}
+          aria-live="assertive"
+          aria-atomic="true"
+          className="sr-only"
+        >
+          {liveMessage}
+        </div>
+      )}
 
-			{newPic && !error && (
-				<div style={{ marginTop: "0.5rem" }}>
-					<button className="px-5 text-white bg-teal-700 hover:bg-teal-800 focus:ring-4 
+      {newPic && !error && (
+        <div style={{ marginTop: "0.5rem" }}>
+          <button
+            className="px-5 text-white bg-teal-700 hover:bg-teal-800 focus:ring-4 
 								  focus:outline-none focus:ring-blue-300 font-medium rounded-lg text-sm w-full 
 								  sm:w-auto py-2.5 text-center dark:bg-teal-600 dark:hover:bg-teal-700
-								  dark:focus:ring-teal-800" onClick={handleSave}>Save</button>
-				</div>
-			)}
-
-		</div>
-	);
+								  dark:focus:ring-teal-800"
+            onClick={handleSave}
+          >
+            Save
+          </button>
+        </div>
+      )}
+    </div>
+  );
 };
 
 export default EditProfilePic;

--- a/frontend/react/src/components/EditProfilePic.tsx
+++ b/frontend/react/src/components/EditProfilePic.tsx
@@ -23,11 +23,13 @@ const EditProfilePic: React.FC<ProfilePicProps> = ({
   const [success, setSuccess] = useState(false);
   const fileInputRef = useRef<HTMLInputElement>(null); // to reset input
   const liveRegionRef = useRef<HTMLDivElement>(null);
-  const [liveMessage, setLiveMessage] = useState<string | null>(null);
+  const [liveMessage, setLiveMessage] = useState<string | null>(null); // for screen reader aria announcements
 
   const allowedTypes = ["image/jpeg", "image/png"];
   const maxSizeMB = 2;
 
+  // This is a workaround for an issue with voiceover moving focus to the wrong place 
+  // (to the entire website window) after exiting a native file upload dialog.
   useEffect(() => {
     if (error || success) {
       setLiveMessage(null); // force remount
@@ -143,6 +145,8 @@ const EditProfilePic: React.FC<ProfilePicProps> = ({
           </span>
         )}
       </div>
+	  {/* This next part is a secret div, visible only to screen readers, which ensures that the error
+	  or success messages get announced using aria. */}
       {liveMessage && (
         <div
           ref={liveRegionRef}

--- a/frontend/react/src/components/SettingsField.tsx
+++ b/frontend/react/src/components/SettingsField.tsx
@@ -71,16 +71,18 @@ const SettingsField: React.FC<FieldProps> = ({
 		setInputValue("");
 		setError(null);
 	};
-
+	const button_aria_label = 'update ' + label;
 	return (
 		<div>
-			<strong>{label}:</strong>{" "}{displayValue}{" "}
+			<label className='font-bold' htmlFor={label + 'btn'}>{label}:</label>{" "}{displayValue}{" "}
 			{!isEditing ? (
 				<>
 					<button className="px-5 mx-3 my-2 text-white bg-teal-700 hover:bg-teal-800 focus:ring-4 
 								  focus:outline-none focus:ring-blue-300 font-semibold rounded-lg text-sm w-full 
 								  sm:w-auto py-2.5 text-center dark:bg-teal-600 dark:hover:bg-teal-700
 								  dark:focus:ring-teal-800"
+							id={label + 'btn'}
+							aria-label={button_aria_label}
 						    onClick={() => {
 						setInputValue("");
 						setIsEditing(true);

--- a/frontend/react/src/components/SettingsField.tsx
+++ b/frontend/react/src/components/SettingsField.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useRef } from "react";
+import React, { useState, useRef, useEffect } from "react";
 
 interface FieldProps {
   label: string;
@@ -8,7 +8,8 @@ interface FieldProps {
   mask?: boolean; // for password
 }
 
-const buttonStyles = "px-5 mx-3 my-2 text-white bg-teal-700 hover:bg-teal-800 focus:ring-4 focus:outline-none focus:ring-blue-300 font-semibold rounded-lg text-sm w-full sm:w-auto py-2.5 text-center dark:bg-teal-600 dark:hover:bg-teal-700 dark:focus:ring-teal-800"
+const buttonStyles =
+  "px-5 mx-3 my-2 text-white bg-teal-700 hover:bg-teal-800 focus:ring-4 focus:outline-none focus:ring-blue-300 font-semibold rounded-lg text-sm w-full sm:w-auto py-2.5 text-center dark:bg-teal-600 dark:hover:bg-teal-700 dark:focus:ring-teal-800";
 /*
 Displays the name of the setting, it's current value next to it (passwords are masked with '*') and
 Update button. When button is clicked, input field opens up with save and cancel option.
@@ -24,8 +25,22 @@ const SettingsField: React.FC<FieldProps> = ({
   const [inputValue, setInputValue] = useState(value);
   const [error, setError] = useState<string | null>(null);
   const inputRef = useRef<HTMLInputElement>(null);
+  const [liveMessage, setLiveMessage] = useState<string | null>(null);
+  const liveRegionRef = useRef<HTMLDivElement>(null); // for screen reader aria announcements
   const mocPwd = "password";
 
+  useEffect(() => {
+    if (error) {
+      setLiveMessage(null); // force remount
+      setTimeout(() => {
+        setLiveMessage(error);
+        // Give React time to render it
+        setTimeout(() => {
+          liveRegionRef.current?.focus();
+        }, 10);
+      }, 100); // wait for file input focus shift to complete
+    }
+  }, [error]);
   const displayValue = mask ? "*".repeat(mocPwd.length) : value;
 
   const validateInput = (input: string) => {
@@ -87,7 +102,8 @@ const SettingsField: React.FC<FieldProps> = ({
             id={label + "btn"}
             aria-label={button_aria_label}
             onClick={() => {
-              setTimeout(() => { // this is necessary to workaround a known issue in Voiceover, which moves the focus to the full window
+              setTimeout(() => {
+                // this is necessary to workaround a known issue in Voiceover, which moves the focus to the full window
                 inputRef.current?.focus();
               }, 10);
               setInputValue("");
@@ -108,13 +124,32 @@ const SettingsField: React.FC<FieldProps> = ({
             onChange={(e) => setInputValue(e.target.value)}
           />
           <div>
-            <button className={buttonStyles} onClick={handleSave} disabled={!inputValue.trim()}>
+            <button
+              className={buttonStyles}
+              onClick={handleSave}
+              disabled={!inputValue.trim()}
+            >
               Save
             </button>{" "}
-            <button className={buttonStyles} onClick={handleCancel}>Cancel</button>
+            <button className={buttonStyles} onClick={handleCancel}>
+              Cancel
+            </button>
           </div>
           {error && (
             <div style={{ color: "red", marginTop: "0.5rem" }}>{error}</div>
+          )}
+          {/* This next part is a secret div, visible only to screen readers, which ensures that the error
+	  or success messages get announced using aria. */}
+          {liveMessage && (
+            <div
+              ref={liveRegionRef}
+              tabIndex={-1}
+              aria-live="assertive"
+              aria-atomic="true"
+              className="sr-only"
+            >
+              {liveMessage}
+            </div>
           )}
         </>
       )}

--- a/frontend/react/src/components/SettingsField.tsx
+++ b/frontend/react/src/components/SettingsField.tsx
@@ -1,11 +1,11 @@
-import React, { useState } from "react";
+import React, { useState, useRef } from "react";
 
 interface FieldProps {
-	label: string;
-	type?: "text" | "email" | "password";
-	value: string;
-	onSave: (val: string) => void;
-	mask?: boolean; // for password
+  label: string;
+  type?: "text" | "email" | "password";
+  value: string;
+  onSave: (val: string) => void;
+  mask?: boolean; // for password
 }
 
 /*
@@ -13,99 +13,115 @@ Displays the name of the setting, it's current value next to it (passwords are m
 Update button. When button is clicked, input field opens up with save and cancel option.
 */
 const SettingsField: React.FC<FieldProps> = ({
-	label,
-	type = "text",
-	value,
-	onSave,
-	mask = false,
+  label,
+  type = "text",
+  value,
+  onSave,
+  mask = false,
 }) => {
-	const [isEditing, setIsEditing] = useState(false);
-	const [inputValue, setInputValue] = useState(value);
-	const [error, setError] = useState<string | null>(null);
+  const [isEditing, setIsEditing] = useState(false);
+  const [inputValue, setInputValue] = useState(value);
+  const [error, setError] = useState<string | null>(null);
+  const inputRef = useRef<HTMLInputElement>(null);
+  const mocPwd = "password";
 
-	const mocPwd = "password";
+  const displayValue = mask ? "*".repeat(mocPwd.length) : value;
 
-	const displayValue = mask ? "*".repeat(mocPwd.length) : value;
+  const validateInput = (input: string) => {
+    const trimmed = input.trim();
+    if (type === "password") {
+      if (trimmed.length < 8 || trimmed.length > 42) {
+        return "Password must be between 8 and 42 characters.";
+      }
+      const pwdRegex =
+        /^(?=.*[a-z])(?=.*[A-Z])(?=.*\d)(?=.*[!@#$%^&*(),.?":{}|<>]).{8,}$/;
+      if (!pwdRegex.test(trimmed)) {
+        return "Password must be at least 8 characters, including uppercase, lowercase, number and special character.";
+      }
+    } else if (type === "email") {
+      if (trimmed.length > 42) {
+        return "Email must be 42 characters of less.";
+      }
+      const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+      if (!emailRegex.test(trimmed)) {
+        return "Please enter a valid email address.";
+      }
+    } else {
+      if (trimmed.length > 42) {
+        return "Value must be less than 42 characters.";
+      }
+    }
+    return null;
+  };
 
-	const validateInput = (input: string) => {
-		const trimmed = input.trim();
-		if (type === "password") {
-			if (trimmed.length < 8 || trimmed.length > 42) {
-				return "Password must be between 8 and 42 characters.";
-			}
-			const pwdRegex = /^(?=.*[a-z])(?=.*[A-Z])(?=.*\d)(?=.*[!@#$%^&*(),.?":{}|<>]).{8,}$/;
-			if (!pwdRegex.test(trimmed)) {
-				return "Password must be at least 8 characters, including uppercase, lowercase, number and special character.";
-			}
-		} else if (type === "email") {
-			if (trimmed.length > 42) {
-				return "Email must be 42 characters of less.";
-			}
-			const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
-			if (!emailRegex.test(trimmed)) {
-				return "Please enter a valid email address.";
-			}
-		} else {
-			if (trimmed.length > 42) {
-				return "Value must be less than 42 characters.";
-			}
-		}
-		return null;
-	};
+  const handleSave = () => {
+    const validationError = validateInput(inputValue);
 
-	const handleSave = () => {
-		const validationError = validateInput(inputValue);
+    if (validationError) {
+      setError(validationError);
+      return;
+    }
+    onSave(inputValue.trim());
+    setIsEditing(false);
+    setInputValue(""); // reset field after save
+    setError(null);
+  };
 
-		if (validationError) {
-			setError(validationError);
-			return;
-		}
-		onSave(inputValue.trim());
-		setIsEditing(false);
-		setInputValue(""); // reset field after save
-		setError(null);
-	};
-
-	const handleCancel = () => {
-		setIsEditing(false);
-		setInputValue("");
-		setError(null);
-	};
-	const button_aria_label = 'update ' + label;
-	return (
-		<div>
-			<label className='font-bold' htmlFor={label + 'btn'}>{label}:</label>{" "}{displayValue}{" "}
-			{!isEditing ? (
-				<>
-					<button className="px-5 mx-3 my-2 text-white bg-teal-700 hover:bg-teal-800 focus:ring-4 
+  const handleCancel = () => {
+    setIsEditing(false);
+    setInputValue("");
+    setError(null);
+  };
+  const button_aria_label = "update " + label;
+  return (
+    <div>
+      <label className="font-bold" htmlFor={label + "btn"}>
+        {label}:
+      </label>{" "}
+      {displayValue}{" "}
+      {!isEditing ? (
+        <>
+          <button
+            className="px-5 mx-3 my-2 text-white bg-teal-700 hover:bg-teal-800 focus:ring-4 
 								  focus:outline-none focus:ring-blue-300 font-semibold rounded-lg text-sm w-full 
 								  sm:w-auto py-2.5 text-center dark:bg-teal-600 dark:hover:bg-teal-700
 								  dark:focus:ring-teal-800"
-							id={label + 'btn'}
-							aria-label={button_aria_label}
-						    onClick={() => {
-						setInputValue("");
-						setIsEditing(true);
-					}}>Update</button>
-				</>
-			) : (
-				<>
-					<br/>
-					<input
-						type={type}
-						value={inputValue}
-						placeholder={`Enter new ${label.toLowerCase()}`}
-						onChange={(e) => setInputValue(e.target.value)}
-					/>
-					<div>
-						<button onClick={handleSave} disabled={!inputValue.trim()}>Save</button>{" "}
-						<button onClick={handleCancel}>Cancel</button>
-					</div>
-					{error && <div style={{ color: "red", marginTop: "0.5rem" }}>{error}</div>}
-				</>
-			)}
-		</div>
-	);
+            id={label + "btn"}
+            aria-label={button_aria_label}
+            onClick={() => {
+              setTimeout(() => {
+                inputRef.current?.focus();
+              }, 10);
+              setInputValue("");
+              setIsEditing(true);
+            }}
+          >
+            Update
+          </button>
+        </>
+      ) : (
+        <>
+          <br />
+          <input
+            type={type}
+            ref={inputRef}
+            value={inputValue}
+            placeholder={`Enter new ${label.toLowerCase()}`}
+            onChange={(e) => setInputValue(e.target.value)}
+          />
+          <div>
+            <button onClick={handleSave} disabled={!inputValue.trim()}>
+              Save
+            </button>{" "}
+            <button onClick={handleCancel}>Cancel</button>
+          </div>
+          {error && (
+            <div style={{ color: "red", marginTop: "0.5rem" }}>{error}</div>
+          )}
+        </>
+      )}
+    </div>
+  );
 };
 
 export default SettingsField;

--- a/frontend/react/src/components/SettingsField.tsx
+++ b/frontend/react/src/components/SettingsField.tsx
@@ -8,6 +8,7 @@ interface FieldProps {
   mask?: boolean; // for password
 }
 
+const buttonStyles = "px-5 mx-3 my-2 text-white bg-teal-700 hover:bg-teal-800 focus:ring-4 focus:outline-none focus:ring-blue-300 font-semibold rounded-lg text-sm w-full sm:w-auto py-2.5 text-center dark:bg-teal-600 dark:hover:bg-teal-700 dark:focus:ring-teal-800"
 /*
 Displays the name of the setting, it's current value next to it (passwords are masked with '*') and
 Update button. When button is clicked, input field opens up with save and cancel option.
@@ -82,14 +83,11 @@ const SettingsField: React.FC<FieldProps> = ({
       {!isEditing ? (
         <>
           <button
-            className="px-5 mx-3 my-2 text-white bg-teal-700 hover:bg-teal-800 focus:ring-4 
-								  focus:outline-none focus:ring-blue-300 font-semibold rounded-lg text-sm w-full 
-								  sm:w-auto py-2.5 text-center dark:bg-teal-600 dark:hover:bg-teal-700
-								  dark:focus:ring-teal-800"
+            className={buttonStyles}
             id={label + "btn"}
             aria-label={button_aria_label}
             onClick={() => {
-              setTimeout(() => {
+              setTimeout(() => { // this is necessary to workaround a known issue in Voiceover, which moves the focus to the full window
                 inputRef.current?.focus();
               }, 10);
               setInputValue("");
@@ -110,10 +108,10 @@ const SettingsField: React.FC<FieldProps> = ({
             onChange={(e) => setInputValue(e.target.value)}
           />
           <div>
-            <button onClick={handleSave} disabled={!inputValue.trim()}>
+            <button className={buttonStyles} onClick={handleSave} disabled={!inputValue.trim()}>
               Save
             </button>{" "}
-            <button onClick={handleCancel}>Cancel</button>
+            <button className={buttonStyles} onClick={handleCancel}>Cancel</button>
           </div>
           {error && (
             <div style={{ color: "red", marginTop: "0.5rem" }}>{error}</div>

--- a/frontend/react/src/components/ToggleSwitch.tsx
+++ b/frontend/react/src/components/ToggleSwitch.tsx
@@ -9,8 +9,8 @@ interface ToggleSwitchProps {
 const ToggleSwitch: React.FC<ToggleSwitchProps> = ({ label, enabled, onToggle }) => {
 	return (
 		<div className="flex justify-between items-center max-w-sm mx-auto my-4">
-			<strong>{label}:</strong>
-			<button
+			<label htmlFor='toggleSwitch' className='font-bold'>{label}:</label>
+			<button id='toggleSwitch'
 				onClick={() => onToggle(!enabled)}
 				className={`w-10 h-5 flex items-center rounded-full p-1 transition-colors ${
 					enabled ? 'bg-teal-600' : 'bg-gray-300'

--- a/frontend/react/src/pages/Register.tsx
+++ b/frontend/react/src/pages/Register.tsx
@@ -1,155 +1,218 @@
-import React, { useState } from 'react';
-import { Link, useNavigate } from 'react-router-dom'
-import  axios from 'axios'
+import React, { useState, useRef, useEffect } from "react";
+import { Link, useNavigate } from "react-router-dom";
+import axios from "axios";
 
-const apiUrl = import.meta.env.VITE_API_BASE_URL || 'api';
+const apiUrl = import.meta.env.VITE_API_BASE_URL || "api";
 
 // tells TypeScript to expect string type values for these attributes
 interface SignUpState {
-	username: string;
-	email: string;
-	password: string;
-	verifypassword: string;
+  username: string;
+  email: string;
+  password: string;
+  verifypassword: string;
 }
 
 const Register: React.FC = () => {
+  // declares a hook assigning empty values to the object
+  const [signupData, setSignupData] = useState<SignUpState>({
+    username: "",
+    email: "",
+    password: "",
+    verifypassword: "",
+  });
 
-	// declares a hook assigning empty values to the object
-	const [signupData, setSignupData] = useState<SignUpState> ({
-		username: '',
-		email: '',
-		password: '',
-		verifypassword: ''
-	})
+  const [errorMessage, setErrorMsg] = useState<string>(""); // custom error message
+  const fileInputRef = useRef<HTMLInputElement>(null); // to reset input
+  const liveRegionRef = useRef<HTMLDivElement>(null);
+  const [liveMessage, setLiveMessage] = useState<string | null>(null); // for screen reader aria announcements
+  useEffect(() => {
+    if (errorMessage) {
+      setLiveMessage(null); // force remount
+      setTimeout(() => {
+        setLiveMessage(errorMessage);
+        // Give React time to render it
+        setTimeout(() => {
+          liveRegionRef.current?.focus();
+        }, 10);
+      }, 100); // wait for file input focus shift to complete
+    }
+  }, [errorMessage]);
 
-	const [errorMessage, setErrorMsg] = useState<string>(''); // custom error message
-	const usernameRegex = /^[a-zA-Z0-9]+$/;
-	const pwdValidationRegex = /^(?=.*[a-z])(?=.*[A-Z])(?=.*\d)(?=.*[!@#$%^&*(),.?":{}|<>]).{8,}$/;
-	const navigate = useNavigate();
+  const usernameRegex = /^[a-zA-Z0-9]+$/;
+  const pwdValidationRegex =
+    /^(?=.*[a-z])(?=.*[A-Z])(?=.*\d)(?=.*[!@#$%^&*(),.?":{}|<>]).{8,}$/;
+  const navigate = useNavigate();
 
-	// saves data to the object
-	const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-		const {name, value} = e.target;
-		setSignupData(prevData => ({...prevData, [name]: value}))
-		setErrorMsg(''); // clears error when user starts typing
-	}
+  // saves data to the object
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const { name, value } = e.target;
+    setSignupData((prevData) => ({ ...prevData, [name]: value }));
+    setErrorMsg(""); // clears error when user starts typing
+  };
 
-	// handles button click: performs password validation and makes post request to db API
-	const handleSubmit = async (e: React.ChangeEvent<HTMLFormElement>) => {
-		e.preventDefault();
+  // handles button click: performs password validation and makes post request to db API
+  const handleSubmit = async (e: React.ChangeEvent<HTMLFormElement>) => {
+    e.preventDefault();
 
-		if (!usernameRegex.test(signupData.username)) {
-			setErrorMsg('Username must contain only letters and numbers.');
-			return;
-		}
+    if (!usernameRegex.test(signupData.username)) {
+      setErrorMsg("Username must contain only letters and numbers.");
+      return;
+    }
 
-		if (!pwdValidationRegex.test(signupData.password)) {
-			setErrorMsg('Password must be at least 8 characters, including uppercase, lowercase, number and special character.');
-			return;
-		}
+    if (!pwdValidationRegex.test(signupData.password)) {
+      setErrorMsg(
+        "Password must be at least 8 characters, including uppercase, lowercase, number and special character."
+      );
+      return;
+    }
 
-		let confirmed: boolean = signupData.password === signupData.verifypassword;
-		if (!confirmed) {
-			setErrorMsg('Passwords don\'t match. Please try again.');
-			return ;
-		}
+    let confirmed: boolean = signupData.password === signupData.verifypassword;
+    if (!confirmed) {
+      setErrorMsg("Passwords don't match. Please try again.");
+      return;
+    }
 
-		try {
+    try {
+      const response = await axios.post(apiUrl + "/users/register", signupData);
+      console.log("Response: ", response);
+      if (response.status === 200) {
+        // const otpResponse = await axios.post(apiUrl + '/auth/send-otp', {
+        // 	email: signupData.email
+        // 	});
+        // 	console.log('OTP Response: ', otpResponse);
+        // navigate('/verifyemail', {
+        navigate("/", {
+          state: {
+            email: signupData.email,
+          },
+        });
+      }
+      return;
+    } catch (error) {
+      console.log(error);
+    }
+  };
+  const labelStyles =
+    "block mb-2 text-sm font-medium text-gray-900 dark:text-white";
+  const inputStyles =
+    "bg-gray-50 border border-gray-300 text-gray-900 text-sm rounded-lg focus:ring-blue-500 focus:border-blue-500 block w-full p-2.5 dark:bg-gray-700 dark:border-gray-600 dark:placeholder-gray-400 dark:text-white dark:focus:ring-blue-500 dark:focus:border-blue-500";
+  return (
+    <div>
+      <h1 className="text-6xl text-center text-teal-800 dark:text-teal-300 m-3">
+        Create an account
+      </h1>
+      <div>
+        <form className="max-w-sm mx-auto" onSubmit={handleSubmit}>
+          <div className="mb-5">
+            <label className={labelStyles} htmlFor="username">
+              Username:{" "}
+            </label>
+            <input
+              className={inputStyles}
+              type="text"
+              id="username"
+              name="username"
+              placeholder="Username"
+              onChange={handleChange}
+              value={signupData.username}
+              required
+              maxLength={20}
+              minLength={2}
+            />
+          </div>
+          <div className="mb-5">
+            <label className={labelStyles} htmlFor="email">
+              Email:{" "}
+            </label>
+            <input
+              className={inputStyles}
+              type="email"
+              id="email"
+              name="email"
+              placeholder="Email"
+              onChange={handleChange}
+              value={signupData.email}
+              required
+              maxLength={42}
+            />
+          </div>
+          <div className="mb-5">
+            <label className={labelStyles} htmlFor="password">
+              Password:
+            </label>
+            <input
+              className={inputStyles}
+              type="password"
+              id="password"
+              name="password"
+              placeholder="Password"
+              onChange={handleChange}
+              value={signupData.password}
+              required
+              maxLength={42}
+              minLength={8}
+            />
+          </div>
+          <div className="mb-5">
+            <label className={labelStyles} htmlFor="verifypassword">
+              Confirm Password:
+            </label>
+            <input
+              className={inputStyles}
+              type="password"
+              id="verifypassword"
+              name="verifypassword"
+              placeholder="Confirm password"
+              onChange={handleChange}
+              value={signupData.verifypassword}
+              required
+              maxLength={42}
+              minLength={8}
+            />
+          </div>
 
-			const response = await axios.post(apiUrl + '/users/register', signupData);
-			console.log('Response: ', response);
-			if (response.status === 200) {
-			// const otpResponse = await axios.post(apiUrl + '/auth/send-otp', {
-			// 	email: signupData.email
-			// 	});
-			// 	console.log('OTP Response: ', otpResponse);	
-				// navigate('/verifyemail', {
-				navigate('/', {
-					state: {
-						email: signupData.email
-					}
-				});
-			}
-			return;
-
-		} catch (error) {
-			console.log(error);
-		}
-	}
-	const labelStyles = "block mb-2 text-sm font-medium text-gray-900 dark:text-white"
-	const inputStyles = "bg-gray-50 border border-gray-300 text-gray-900 text-sm rounded-lg focus:ring-blue-500 focus:border-blue-500 block w-full p-2.5 dark:bg-gray-700 dark:border-gray-600 dark:placeholder-gray-400 dark:text-white dark:focus:ring-blue-500 dark:focus:border-blue-500"
-	return (
-    	<div>
-			<h1 className="text-6xl text-center text-teal-800 dark:text-teal-300 m-3">Create an account</h1>
-			<div>
-			<form className="max-w-sm mx-auto" onSubmit={handleSubmit}>
-				<div className="mb-5"><label className={labelStyles} htmlFor="username">Username: </label>
-				<input className={inputStyles}
-					type="text"
-					id="username"
-					name="username"
-					placeholder="Username"
-					onChange={handleChange}
-					value={signupData.username}
-					required
-					maxLength={20}
-					minLength={2}
-				/></div>
-				<div className="mb-5"><label className={labelStyles} htmlFor="email">Email: </label>
-				<input className={inputStyles}
-					type="email"
-					id="email"
-					name="email"
-					placeholder="Email"
-					onChange={handleChange}
-					value={signupData.email}
-					required
-					maxLength={42}
-				/></div>
-				<div className="mb-5"><label className={labelStyles} htmlFor="password">Password:</label>
-				<input className={inputStyles}
-					type="password"
-					id="password"
-					name="password"
-					placeholder="Password"
-					onChange={handleChange}
-					value={signupData.password}
-					required
-					maxLength={42}
-					minLength={8}
-				/></div>
-				<div className="mb-5"><label className={labelStyles} htmlFor="verifypassword">Confirm Password:</label>
-				<input className={inputStyles}
-					type="password"
-					id="verifypassword"
-					name="verifypassword"
-					placeholder="Confirm password"
-					onChange={handleChange}
-					value={signupData.verifypassword}
-					required
-					maxLength={42}
-					minLength={8}
-				/></div>
-
-				{errorMessage && (
-					<p style={{ color: 'red', marginTop: '8px'}}>{errorMessage}</p>
-				)}
-
-				<button className="block mx-auto px-20 text-white bg-teal-700 hover:bg-teal-800 focus:ring-4 
+          {errorMessage && (
+            <p style={{ color: "red", marginTop: "8px" }}>{errorMessage}</p>
+          )}
+          {/* This next part is a secret div, visible only to screen readers, which ensures that the error
+	  or success messages get announced using aria. */}
+          {liveMessage && (
+            <div
+              ref={liveRegionRef}
+              tabIndex={-1}
+              aria-live="assertive"
+              aria-atomic="true"
+              className="sr-only"
+            >
+              {liveMessage}
+            </div>
+          )}
+          <button
+            className="block mx-auto px-20 text-white bg-teal-700 hover:bg-teal-800 focus:ring-4 
 								  focus:outline-none focus:ring-blue-300 font-medium rounded-lg text-sm w-full 
 								  sm:w-auto py-2.5 text-center dark:bg-teal-600 dark:hover:bg-teal-700
-								  dark:focus:ring-teal-800" type="submit">Register</button>
-			</form></div>
+								  dark:focus:ring-teal-800"
+            type="submit"
+          >
+            Register
+          </button>
+        </form>
+      </div>
 
-			<p className="m-5 text-center dark:text-white">
-				Already have an account? <Link className="text-white bg-amber-700 hover:bg-amber-800 
+      <p className="m-5 text-center dark:text-white">
+        Already have an account?{" "}
+        <Link
+          className="text-white bg-amber-700 hover:bg-amber-800 
 										 focus:ring-4 focus:outline-none focus:ring-blue-300 font-medium 
 										 rounded-lg text-sm w-full sm:w-auto px-5 py-2.5 mx-3 text-center
 										  dark:bg-amber-600 dark:hover:bg-amber-700 dark:focus:ring-amber-800"
-										  to="/login">Login</Link>
-			</p>
-		</div>
-	)
-}
+          to="/login"
+        >
+          Login
+        </Link>
+      </p>
+    </div>
+  );
+};
 
-export default Register
+export default Register;


### PR DESCRIPTION
The site design was revamped a bit with a focus on accessibility using a screen reader. The visual layout is mostly the same (I styled a few elements that had been missed before when I was doing the tailwind stuff). 

Main changes:
1) Some labels were not associated properly with their respective buttons (using htmlFor)
2) Hidden screen-reader only divs added, to ensure that aria-live announcements work properly for error messages, so when a file upload fails, or form validation fails there is an immediate audio alert. This also required a separate useState for the live messages.
3) Clicking the update email or password buttons forces focus to the appropriate text input box.

None of this should affect the normal visual user experience; if you notice any issues let me know.
 
This was tested on Mac OS and Kubuntu Linux, using the VoiceOver and Orca screen readers (Orca is the one we have at school).