### PR TITLE
Improve redirection logic upon session expiry

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -16,7 +16,7 @@
         "@fastify/multipart": "^9.0.3",
         "@fastify/rate-limit": "^10.3.0",
         "@fastify/static": "^8.2.0",
-        "@prisma/client": "^6.9.0",
+        "@prisma/client": "^6.10.1",
         "bcryptjs": "^2.4.3",
         "dotenv": "^16.5.0",
         "fastify": "^5.2.2",
@@ -31,7 +31,7 @@
         "eslint-plugin-react": "^7.37.5",
         "globals": "^16.2.0",
         "nodemon": "^3.1.9",
-        "prisma": "^6.9.0"
+        "prisma": "^6.10.1"
       }
     },
     "node_modules/@emnapi/runtime": {
@@ -1162,9 +1162,9 @@
       }
     },
     "node_modules/@prisma/client": {
-      "version": "6.9.0",
-      "resolved": "https://registry.npmjs.org/@prisma/client/-/client-6.9.0.tgz",
-      "integrity": "sha512-Gg7j1hwy3SgF1KHrh0PZsYvAaykeR0PaxusnLXydehS96voYCGt1U5zVR31NIouYc63hWzidcrir1a7AIyCsNQ==",
+      "version": "6.10.1",
+      "resolved": "https://registry.npmjs.org/@prisma/client/-/client-6.10.1.tgz",
+      "integrity": "sha512-Re4pMlcUsQsUTAYMK7EJ4Bw2kg3WfZAAlr8GjORJaK4VOP6LxRQUQ1TuLnxcF42XqGkWQ36q5CQF1yVadANQ6w==",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "engines": {
@@ -1184,9 +1184,9 @@
       }
     },
     "node_modules/@prisma/config": {
-      "version": "6.9.0",
-      "resolved": "https://registry.npmjs.org/@prisma/config/-/config-6.9.0.tgz",
-      "integrity": "sha512-Wcfk8/lN3WRJd5w4jmNQkUwhUw0eksaU/+BlAJwPQKW10k0h0LC9PD/6TQFmqKVbHQL0vG2z266r0S1MPzzhbA==",
+      "version": "6.10.1",
+      "resolved": "https://registry.npmjs.org/@prisma/config/-/config-6.10.1.tgz",
+      "integrity": "sha512-kz4/bnqrOrzWo8KzYguN0cden4CzLJJ+2VSpKtF8utHS3l1JS0Lhv6BLwpOX6X9yNreTbZQZwewb+/BMPDCIYQ==",
       "devOptional": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -1194,53 +1194,53 @@
       }
     },
     "node_modules/@prisma/debug": {
-      "version": "6.9.0",
-      "resolved": "https://registry.npmjs.org/@prisma/debug/-/debug-6.9.0.tgz",
-      "integrity": "sha512-bFeur/qi/Q+Mqk4JdQ3R38upSYPebv5aOyD1RKywVD+rAMLtRkmTFn28ZuTtVOnZHEdtxnNOCH+bPIeSGz1+Fg==",
+      "version": "6.10.1",
+      "resolved": "https://registry.npmjs.org/@prisma/debug/-/debug-6.10.1.tgz",
+      "integrity": "sha512-k2YT53cWxv9OLjW4zSYTZ6Z7j0gPfCzcr2Mj99qsuvlxr8WAKSZ2NcSR0zLf/mP4oxnYG842IMj3utTgcd7CaA==",
       "devOptional": true,
       "license": "Apache-2.0"
     },
     "node_modules/@prisma/engines": {
-      "version": "6.9.0",
-      "resolved": "https://registry.npmjs.org/@prisma/engines/-/engines-6.9.0.tgz",
-      "integrity": "sha512-im0X0bwDLA0244CDf8fuvnLuCQcBBdAGgr+ByvGfQY9wWl6EA+kRGwVk8ZIpG65rnlOwtaWIr/ZcEU5pNVvq9g==",
+      "version": "6.10.1",
+      "resolved": "https://registry.npmjs.org/@prisma/engines/-/engines-6.10.1.tgz",
+      "integrity": "sha512-Q07P5rS2iPwk2IQr/rUQJ42tHjpPyFcbiH7PXZlV81Ryr9NYIgdxcUrwgVOWVm5T7ap02C0dNd1dpnNcSWig8A==",
       "devOptional": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@prisma/debug": "6.9.0",
-        "@prisma/engines-version": "6.9.0-10.81e4af48011447c3cc503a190e86995b66d2a28e",
-        "@prisma/fetch-engine": "6.9.0",
-        "@prisma/get-platform": "6.9.0"
+        "@prisma/debug": "6.10.1",
+        "@prisma/engines-version": "6.10.1-1.9b628578b3b7cae625e8c927178f15a170e74a9c",
+        "@prisma/fetch-engine": "6.10.1",
+        "@prisma/get-platform": "6.10.1"
       }
     },
     "node_modules/@prisma/engines-version": {
-      "version": "6.9.0-10.81e4af48011447c3cc503a190e86995b66d2a28e",
-      "resolved": "https://registry.npmjs.org/@prisma/engines-version/-/engines-version-6.9.0-10.81e4af48011447c3cc503a190e86995b66d2a28e.tgz",
-      "integrity": "sha512-Qp9gMoBHgqhKlrvumZWujmuD7q4DV/gooEyPCLtbkc13EZdSz2RsGUJ5mHb3RJgAbk+dm6XenqG7obJEhXcJ6Q==",
+      "version": "6.10.1-1.9b628578b3b7cae625e8c927178f15a170e74a9c",
+      "resolved": "https://registry.npmjs.org/@prisma/engines-version/-/engines-version-6.10.1-1.9b628578b3b7cae625e8c927178f15a170e74a9c.tgz",
+      "integrity": "sha512-ZJFTsEqapiTYVzXya6TUKYDFnSWCNegfUiG5ik9fleQva5Sk3DNyyUi7X1+0ZxWFHwHDr6BZV5Vm+iwP+LlciA==",
       "devOptional": true,
       "license": "Apache-2.0"
     },
     "node_modules/@prisma/fetch-engine": {
-      "version": "6.9.0",
-      "resolved": "https://registry.npmjs.org/@prisma/fetch-engine/-/fetch-engine-6.9.0.tgz",
-      "integrity": "sha512-PMKhJdl4fOdeE3J3NkcWZ+tf3W6rx3ht/rLU8w4SXFRcLhd5+3VcqY4Kslpdm8osca4ej3gTfB3+cSk5pGxgFg==",
+      "version": "6.10.1",
+      "resolved": "https://registry.npmjs.org/@prisma/fetch-engine/-/fetch-engine-6.10.1.tgz",
+      "integrity": "sha512-clmbG/Jgmrc/n6Y77QcBmAUlq9LrwI9Dbgy4pq5jeEARBpRCWJDJ7PWW1P8p0LfFU0i5fsyO7FqRzRB8mkdS4g==",
       "devOptional": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@prisma/debug": "6.9.0",
-        "@prisma/engines-version": "6.9.0-10.81e4af48011447c3cc503a190e86995b66d2a28e",
-        "@prisma/get-platform": "6.9.0"
+        "@prisma/debug": "6.10.1",
+        "@prisma/engines-version": "6.10.1-1.9b628578b3b7cae625e8c927178f15a170e74a9c",
+        "@prisma/get-platform": "6.10.1"
       }
     },
     "node_modules/@prisma/get-platform": {
-      "version": "6.9.0",
-      "resolved": "https://registry.npmjs.org/@prisma/get-platform/-/get-platform-6.9.0.tgz",
-      "integrity": "sha512-/B4n+5V1LI/1JQcHp+sUpyRT1bBgZVPHbsC4lt4/19Xp4jvNIVcq5KYNtQDk5e/ukTSjo9PZVAxxy9ieFtlpTQ==",
+      "version": "6.10.1",
+      "resolved": "https://registry.npmjs.org/@prisma/get-platform/-/get-platform-6.10.1.tgz",
+      "integrity": "sha512-4CY5ndKylcsce9Mv+VWp5obbR2/86SHOLVV053pwIkhVtT9C9A83yqiqI/5kJM9T1v1u1qco/bYjDKycmei9HA==",
       "devOptional": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@prisma/debug": "6.9.0"
+        "@prisma/debug": "6.10.1"
       }
     },
     "node_modules/@tokenizer/inflate": {
@@ -5157,15 +5157,15 @@
       }
     },
     "node_modules/prisma": {
-      "version": "6.9.0",
-      "resolved": "https://registry.npmjs.org/prisma/-/prisma-6.9.0.tgz",
-      "integrity": "sha512-resJAwMyZREC/I40LF6FZ6rZTnlrlrYrb63oW37Gq+U+9xHwbyMSPJjKtM7VZf3gTO86t/Oyz+YeSXr3CmAY1Q==",
+      "version": "6.10.1",
+      "resolved": "https://registry.npmjs.org/prisma/-/prisma-6.10.1.tgz",
+      "integrity": "sha512-khhlC/G49E4+uyA3T3H5PRBut486HD2bDqE2+rvkU0pwk9IAqGFacLFUyIx9Uw+W2eCtf6XGwsp+/strUwMNPw==",
       "devOptional": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@prisma/config": "6.9.0",
-        "@prisma/engines": "6.9.0"
+        "@prisma/config": "6.10.1",
+        "@prisma/engines": "6.10.1"
       },
       "bin": {
         "prisma": "build/index.js"

--- a/backend/package.json
+++ b/backend/package.json
@@ -25,7 +25,7 @@
     "@fastify/multipart": "^9.0.3",
     "@fastify/rate-limit": "^10.3.0",
     "@fastify/static": "^8.2.0",
-    "@prisma/client": "^6.9.0",
+    "@prisma/client": "^6.10.1",
     "bcryptjs": "^2.4.3",
     "dotenv": "^16.5.0",
     "fastify": "^5.2.2",
@@ -40,6 +40,6 @@
     "eslint-plugin-react": "^7.37.5",
     "globals": "^16.2.0",
     "nodemon": "^3.1.9",
-    "prisma": "^6.9.0"
+    "prisma": "^6.10.1"
   }
 }

--- a/backend/srcs/middleware/authenticate.js
+++ b/backend/srcs/middleware/authenticate.js
@@ -22,8 +22,7 @@ export async function authenticate(request, reply) {
 			return reply.code(419).send({ error: 'Session expired' });
 		}
 		// If the token is about to expire (less than 15 minutes left), refresh it
-		//if (timeLeft < 15 * 60) {
-		if (timeLeft < 2 * 60) {
+		if (timeLeft < 15 * 60) {
 		// Create a new token with the same payload and a new expiration time
 		const newToken = await request.jwtSign(
 			{
@@ -31,8 +30,7 @@ export async function authenticate(request, reply) {
 			username: currentToken.username,
 			},
 			{
-			//expiresIn: '1h', // New expiration time
-			expiresIn: '5m',
+			expiresIn: '1h', // New expiration time
 			}
 		);
 		// Set the new token in the cookie
@@ -41,8 +39,7 @@ export async function authenticate(request, reply) {
 			secure: process.env.NODE_ENV === 'production',
 			sameSite: 'strict',
 			path: '/',
-			maxAge: 5 * 60,
-			//maxAge: 60 * 60, // 1 hour in seconds
+			maxAge: 60 * 60, // 1 hour in seconds
 		});
 		}
   } catch (err) {

--- a/backend/srcs/middleware/authenticate.js
+++ b/backend/srcs/middleware/authenticate.js
@@ -15,29 +15,36 @@ export async function authenticate(request, reply) {
 
     console.log("Authenticated user:", request.user);
 
-    const now = Math.floor(Date.now() / 1000); // Get the current time in seconds
-    const timeLeft = currentToken.exp - now; // Calculate the time left until expiration
-    // If the token is about to expire (less than 15 minutes left), refresh it
-    if (timeLeft < 15 * 60) {
-      // Create a new token with the same payload and a new expiration time
-      const newToken = await request.jwtSign(
-        {
-          id: currentToken.id,
-          username: currentToken.username,
-        },
-        {
-          expiresIn: "1h", // New expiration time
-        }
-      );
-      // Set the new token in the cookie
-      reply.setCookie("token", newToken, {
-        httpOnly: true,
-        secure: process.env.NODE_ENV === "production",
-        sameSite: "strict",
-        path: "/",
-        maxAge: 60 * 60, // 1 hour in seconds
-      });
-    }
+		const now = Math.floor(Date.now() / 1000); // Get the current time in seconds
+		const timeLeft = currentToken.exp - now; // Calculate the time left until expiration
+
+		if (timeLeft <= 0) {
+			return reply.code(419).send({ error: 'Session expired' });
+		}
+		// If the token is about to expire (less than 15 minutes left), refresh it
+		//if (timeLeft < 15 * 60) {
+		if (timeLeft < 2 * 60) {
+		// Create a new token with the same payload and a new expiration time
+		const newToken = await request.jwtSign(
+			{
+			id: currentToken.id,
+			username: currentToken.username,
+			},
+			{
+			//expiresIn: '1h', // New expiration time
+			expiresIn: '5m',
+			}
+		);
+		// Set the new token in the cookie
+		reply.setCookie('token', newToken, {
+			httpOnly: true,
+			secure: process.env.NODE_ENV === 'production',
+			sameSite: 'strict',
+			path: '/',
+			maxAge: 5 * 60,
+			//maxAge: 60 * 60, // 1 hour in seconds
+		});
+		}
   } catch (err) {
     // If the token is invalid, return a 401 Unauthorized response
     return reply.code(401).send({ error: "Unauthorized" });

--- a/backend/srcs/middleware/authenticate.js
+++ b/backend/srcs/middleware/authenticate.js
@@ -15,33 +15,33 @@ export async function authenticate(request, reply) {
 
     console.log("Authenticated user:", request.user);
 
-		const now = Math.floor(Date.now() / 1000); // Get the current time in seconds
-		const timeLeft = currentToken.exp - now; // Calculate the time left until expiration
+    const now = Math.floor(Date.now() / 1000); // Get the current time in seconds
+    const timeLeft = currentToken.exp - now; // Calculate the time left until expiration
 
-		if (timeLeft <= 0) {
-			return reply.code(419).send({ error: 'Session expired' });
-		}
-		// If the token is about to expire (less than 15 minutes left), refresh it
-		if (timeLeft < 15 * 60) {
-		// Create a new token with the same payload and a new expiration time
-		const newToken = await request.jwtSign(
-			{
-			id: currentToken.id,
-			username: currentToken.username,
-			},
-			{
-			expiresIn: '1h', // New expiration time
-			}
-		);
-		// Set the new token in the cookie
-		reply.setCookie('token', newToken, {
-			httpOnly: true,
-			secure: process.env.NODE_ENV === 'production',
-			sameSite: 'strict',
-			path: '/',
-			maxAge: 60 * 60, // 1 hour in seconds
-		});
-		}
+    if (timeLeft <= 0) {
+      return reply.code(419).send({ error: "Session expired" });
+    }
+    // If the token is about to expire (less than 15 minutes left), refresh it
+    if (timeLeft < 15 * 60) {
+      // Create a new token with the same payload and a new expiration time
+      const newToken = await request.jwtSign(
+        {
+          id: currentToken.id,
+          username: currentToken.username,
+        },
+        {
+          expiresIn: "1h", // New expiration time
+        }
+      );
+      // Set the new token in the cookie
+      reply.setCookie("token", newToken, {
+        httpOnly: true,
+        secure: process.env.NODE_ENV === "production",
+        sameSite: "strict",
+        path: "/",
+        maxAge: 60 * 60, // 1 hour in seconds
+      });
+    }
   } catch (err) {
     // If the token is invalid, return a 401 Unauthorized response
     return reply.code(401).send({ error: "Unauthorized" });

--- a/backend/srcs/middleware/authenticateOptional.js
+++ b/backend/srcs/middleware/authenticateOptional.js
@@ -4,41 +4,41 @@ export async function authenticateOptional(request, reply) {
     // Check if the request has a valid JWT token and store it for time validation
     const currentToken = await request.jwtVerify();
 
-		if (!currentToken?.id || !currentToken?.username) {
-			request.user = undefined;
-			return;
-		}
+    if (!currentToken?.id || !currentToken?.username) {
+      request.user = undefined;
+      return;
+    }
 
     request.user = {
       id: currentToken.id,
       username: currentToken.username,
     };
 
-		const now = Math.floor(Date.now() / 1000); // Get the current time in seconds
-		const timeLeft = currentToken.exp - now; // Calculate the time left until expiration
+    const now = Math.floor(Date.now() / 1000); // Get the current time in seconds
+    const timeLeft = currentToken.exp - now; // Calculate the time left until expiration
 
-		if (timeLeft <= 0) {
-			request.user = undefined;
-			return reply.code(419).send({ error: 'Session expired' });
-		}
-		// If the token is about to expire (less than 15 minutes left), refresh it
-		if (timeLeft < 15 * 60) {
-		// Create a new token with the same payload and a new expiration time
-		const newToken = await request.jwtSign(
-			{ id: currentToken.id, username: currentToken.username },
-			{ expiresIn: '1h' },
-		);
-		// Set the new token in the cookie
-		reply.setCookie('token', newToken, {
-			httpOnly: true,
-			secure: process.env.NODE_ENV === 'production',
-			sameSite: 'strict',
-			path: '/',
-			maxAge: 60 * 60, // 1 hour in seconds
-		});
-		}
+    if (timeLeft <= 0) {
+      request.user = undefined;
+      return reply.code(419).send({ error: "Session expired" });
+    }
+    // If the token is about to expire (less than 15 minutes left), refresh it
+    if (timeLeft < 15 * 60) {
+      // Create a new token with the same payload and a new expiration time
+      const newToken = await request.jwtSign(
+        { id: currentToken.id, username: currentToken.username },
+        { expiresIn: "1h" }
+      );
+      // Set the new token in the cookie
+      reply.setCookie("token", newToken, {
+        httpOnly: true,
+        secure: process.env.NODE_ENV === "production",
+        sameSite: "strict",
+        path: "/",
+        maxAge: 60 * 60, // 1 hour in seconds
+      });
+    }
   } catch (err) {
-	// invalid or no token - no need to throw
-	request.user = undefined;
+    // invalid or no token - no need to throw
+    request.user = undefined;
   }
 }

--- a/backend/srcs/middleware/authenticateOptional.js
+++ b/backend/srcs/middleware/authenticateOptional.js
@@ -4,35 +4,44 @@ export async function authenticateOptional(request, reply) {
     // Check if the request has a valid JWT token and store it for time validation
     const currentToken = await request.jwtVerify();
 
-    if (!currentToken?.id || !currentToken?.username) {
-      return;
-    }
+		if (!currentToken?.id || !currentToken?.username) {
+			request.user = undefined;
+			return;
+		}
 
     request.user = {
       id: currentToken.id,
       username: currentToken.username,
     };
 
-    const now = Math.floor(Date.now() / 1000); // Get the current time in seconds
-    const timeLeft = currentToken.exp - now; // Calculate the time left until expiration
-    // If the token is about to expire (less than 15 minutes left), refresh it
-    if (timeLeft < 15 * 60) {
-      // Create a new token with the same payload and a new expiration time
-      const newToken = await request.jwtSign(
-        { id: currentToken.id, username: currentToken.username },
-        { expiresIn: "1h" }
-      );
-      // Set the new token in the cookie
-      reply.setCookie("token", newToken, {
-        httpOnly: true,
-        secure: process.env.NODE_ENV === "production",
-        sameSite: "strict",
-        path: "/",
-        maxAge: 60 * 60, // 1 hour in seconds
-      });
-    }
+		const now = Math.floor(Date.now() / 1000); // Get the current time in seconds
+		const timeLeft = currentToken.exp - now; // Calculate the time left until expiration
+
+		if (timeLeft <= 0) {
+			request.user = undefined;
+			return reply.code(419).send({ error: 'Session expired' });
+		}
+		// If the token is about to expire (less than 15 minutes left), refresh it
+		//if (timeLeft < 15 * 60) {
+		if (timeLeft < 2 * 60) {
+		// Create a new token with the same payload and a new expiration time
+		const newToken = await request.jwtSign(
+			{ id: currentToken.id, username: currentToken.username },
+			//{ expiresIn: '1h' },
+			{ expiresIn: '5m' },
+		);
+		// Set the new token in the cookie
+		reply.setCookie('token', newToken, {
+			httpOnly: true,
+			secure: process.env.NODE_ENV === 'production',
+			sameSite: 'strict',
+			path: '/',
+			maxAge: 60 * 60,
+			//maxAge: 60 * 60, // 1 hour in seconds
+		});
+		}
   } catch (err) {
-    // invalid or no token - no need to throw
-    return;
+	// invalid or no token - no need to throw
+	request.user = undefined;
   }
 }

--- a/backend/srcs/middleware/authenticateOptional.js
+++ b/backend/srcs/middleware/authenticateOptional.js
@@ -22,13 +22,11 @@ export async function authenticateOptional(request, reply) {
 			return reply.code(419).send({ error: 'Session expired' });
 		}
 		// If the token is about to expire (less than 15 minutes left), refresh it
-		//if (timeLeft < 15 * 60) {
-		if (timeLeft < 2 * 60) {
+		if (timeLeft < 15 * 60) {
 		// Create a new token with the same payload and a new expiration time
 		const newToken = await request.jwtSign(
 			{ id: currentToken.id, username: currentToken.username },
-			//{ expiresIn: '1h' },
-			{ expiresIn: '5m' },
+			{ expiresIn: '1h' },
 		);
 		// Set the new token in the cookie
 		reply.setCookie('token', newToken, {
@@ -36,8 +34,7 @@ export async function authenticateOptional(request, reply) {
 			secure: process.env.NODE_ENV === 'production',
 			sameSite: 'strict',
 			path: '/',
-			maxAge: 60 * 60,
-			//maxAge: 60 * 60, // 1 hour in seconds
+			maxAge: 60 * 60, // 1 hour in seconds
 		});
 		}
   } catch (err) {

--- a/backend/srcs/routes/users.js
+++ b/backend/srcs/routes/users.js
@@ -67,13 +67,11 @@ export async function userRoutes(fastify, options) {
               path: "/",
               maxAge: 5 * 60,
             });
-            return reply
-              .code(200)
-              .send({
-                message: "MFA still required",
-                mfaRequired: true,
-                language: user.language || "en",
-              });
+            return reply.code(200).send({
+              message: "MFA still required",
+              mfaRequired: true,
+              language: user.language || "en",
+            });
           } catch (error) {
             return reply.code(401).send({ error: "Invalid email for mfa" });
           }
@@ -101,12 +99,10 @@ export async function userRoutes(fastify, options) {
           maxAge: 60 * 60, // 1 hour in seconds, same as JWT expiration
         });
         // send response with without token (token is in the cookie)
-        return reply
-          .code(200)
-          .send({
-            message: "Login successful",
-            language: user.language || "en",
-          });
+        return reply.code(200).send({
+          message: "Login successful",
+          language: user.language || "en",
+        });
       } catch (error) {
         return reply.code(500).send({ error: "Internal server error" });
       }

--- a/backend/srcs/schemas/userSchemas.js
+++ b/backend/srcs/schemas/userSchemas.js
@@ -2,6 +2,7 @@
 
 // This schema is used to validate the id for deleting a user
 const deleteUserSchema = {
+<<<<<<< HEAD
   params: {
     type: "object",
     properties: {
@@ -15,6 +16,21 @@ const deleteUserSchema = {
     404: { type: "object", properties: { error: { type: "string" } } },
   },
 };
+=======
+	params: {
+	  type: 'object',
+	  properties: {
+		id: { type: 'integer', minimum: 1 },
+	  },
+	  required: ['id'],
+	},
+	response: {
+	  200: { type: 'object', properties: { message: { type: 'string' } } },
+	  400: { type: 'object', properties: { error: { type: 'string' } } },
+	  404: { type: 'object', properties: { error: { type: 'string' } } },
+	},
+  };
+>>>>>>> a16f332 (finished users and otp schemas)
 
 // This schema is used to validate the id and password for deleteing a user
 const deleteUserSchemaPost = {

--- a/backend/srcs/schemas/userSchemas.js
+++ b/backend/srcs/schemas/userSchemas.js
@@ -2,7 +2,6 @@
 
 // This schema is used to validate the id for deleting a user
 const deleteUserSchema = {
-<<<<<<< HEAD
   params: {
     type: "object",
     properties: {
@@ -16,21 +15,6 @@ const deleteUserSchema = {
     404: { type: "object", properties: { error: { type: "string" } } },
   },
 };
-=======
-	params: {
-	  type: 'object',
-	  properties: {
-		id: { type: 'integer', minimum: 1 },
-	  },
-	  required: ['id'],
-	},
-	response: {
-	  200: { type: 'object', properties: { message: { type: 'string' } } },
-	  400: { type: 'object', properties: { error: { type: 'string' } } },
-	  404: { type: 'object', properties: { error: { type: 'string' } } },
-	},
-  };
->>>>>>> a16f332 (finished users and otp schemas)
 
 // This schema is used to validate the id and password for deleteing a user
 const deleteUserSchemaPost = {

--- a/frontend/react/src/App.tsx
+++ b/frontend/react/src/App.tsx
@@ -1,47 +1,36 @@
-import React from "react";
-import {
-  Routes,
-  Route,
-  Navigate,
-} from "react-router-dom";
-import Login from "./pages/Login";
-import Register from "./pages/Register";
-import Home from "./pages/Home";
-import PongPals from "./pages/PongPals";
-import Settings from "./pages/Settings";
-import ForgotPassword from "./pages/ForgotPassword";
-import Stats from "./pages/Stats";
-import VerifyEmail from "./pages/VerifyEmail";
-import showDatabase from "./components/showDatabase";
-import NavigationHeader from "./components/NavigationHeader";
-import { useAuth } from "./auth/AuthProvider";
-import axios from "axios";
-import Mfa from "./pages/Mfa";
-import i18n from "./i18n";
+import React from 'react'
+import { Routes, Route, Navigate } from 'react-router-dom'
+import Login from './pages/Login';
+import Register from './pages/Register';
+import Home from './pages/Home';
+import PongPals from './pages/PongPals';
+import Settings from './pages/Settings';
+import ForgotPassword from './pages/ForgotPassword';
+import Stats from './pages/Stats';
+import VerifyEmail from './pages/VerifyEmail';
+import showDatabase from './components/showDatabase';
+import NavigationHeader from './components/NavigationHeader';
+import { useAuth } from './auth/AuthProvider';
+import api from './api/axios';
+import Mfa from './pages/Mfa';
+import i18n from './i18n';
 
 const App: React.FC = () => {
-  const apiUrl = import.meta.env.VITE_API_BASE_URL || "/api";
 
-  const logout = async () => {
-    try {
-      await axios.post(
-        apiUrl + "/users/logout",
-        {},
-        {
-          headers: {
-            "Content-Type": "application/json",
-          },
-          withCredentials: true,
-        }
-      );
-      i18n.changeLanguage("en");
-      localStorage.removeItem("language");
-      await refreshSession();
-    } catch (error) {
-      console.error("Error logging out: ", error);
-    }
-  };
-  const { status, user, refreshSession } = useAuth();
+	const logout = async () => {
+		try {
+			await api.post('/users/logout', {}, {
+				headers: { "Content-Type": "application/json" },
+			});
+			i18n.changeLanguage('en');
+    		localStorage.removeItem('language')
+			await refreshSession();
+			
+		} catch (error) {
+			console.error("Error logging out: ", error);
+		}
+	}
+	const { status, user, refreshSession } = useAuth();
   return (
 	<>
 		<NavigationHeader handleLogout={logout} status={status} user={user}/>

--- a/frontend/react/src/App.tsx
+++ b/frontend/react/src/App.tsx
@@ -1,57 +1,68 @@
-import React from 'react'
-import { Routes, Route, Navigate } from 'react-router-dom'
-import Login from './pages/Login';
-import Register from './pages/Register';
-import Home from './pages/Home';
-import PongPals from './pages/PongPals';
-import Settings from './pages/Settings';
-import ForgotPassword from './pages/ForgotPassword';
-import Stats from './pages/Stats';
-import VerifyEmail from './pages/VerifyEmail';
-import showDatabase from './components/showDatabase';
-import NavigationHeader from './components/NavigationHeader';
-import { useAuth } from './auth/AuthProvider';
-import api from './api/axios';
-import Mfa from './pages/Mfa';
-import i18n from './i18n';
+import React from "react";
+import { Routes, Route, Navigate } from "react-router-dom";
+import Login from "./pages/Login";
+import Register from "./pages/Register";
+import Home from "./pages/Home";
+import PongPals from "./pages/PongPals";
+import Settings from "./pages/Settings";
+import ForgotPassword from "./pages/ForgotPassword";
+import Stats from "./pages/Stats";
+import VerifyEmail from "./pages/VerifyEmail";
+import showDatabase from "./components/showDatabase";
+import NavigationHeader from "./components/NavigationHeader";
+import { useAuth } from "./auth/AuthProvider";
+import api from "./api/axios";
+import Mfa from "./pages/Mfa";
+import i18n from "./i18n";
 
 const App: React.FC = () => {
-
-	const logout = async () => {
-		try {
-			await api.post('/users/logout', {}, {
-				headers: { "Content-Type": "application/json" },
-			});
-			i18n.changeLanguage('en');
-    		localStorage.removeItem('language')
-			await refreshSession();
-			
-		} catch (error) {
-			console.error("Error logging out: ", error);
-		}
-	}
-	const { status, user, refreshSession } = useAuth();
+  const logout = async () => {
+    try {
+      await api.post(
+        "/users/logout",
+        {},
+        {
+          headers: { "Content-Type": "application/json" },
+        }
+      );
+      i18n.changeLanguage("en");
+      localStorage.removeItem("language");
+      await refreshSession();
+    } catch (error) {
+      console.error("Error logging out: ", error);
+    }
+  };
+  const { status, user, refreshSession } = useAuth();
   return (
-	<>
-		<NavigationHeader handleLogout={logout} status={status} user={user}/>
-		<Routes>
-			<Route path="/" element={<Home status={status} user={user}/>} />
-			<Route path="/register" element={<Register />} />
-			<Route path="/login" element={<Login />} />
-			<Route path="/forgotpassword" element={<ForgotPassword />} />
-			<Route path="/verifyemail" element={<VerifyEmail />} />
-			<Route path="/pongpals" element={<PongPals />} />
-			<Route path="/settings" element={<Settings />} />
-			<Route path="/stats" element={<Stats />} />
-			<Route path="/mfa" element={<Mfa />} />
-			<Route path="*" element={<Navigate to="/" replace/>} />
-			<Route path="/stats/:anything" element={<Navigate to="/stats" replace/>}/>
-		</Routes>
-		<div className="flex justify-center my-4"><button className="border bg-teal-500 font-semibold hover:font-extrabold 
-					  hover:underline uppercase text-white p-4 mx-4 rounded-2xl" 
-					  onClick={showDatabase}>show Database (for dev use only)</button></div>
+    <>
+      <NavigationHeader handleLogout={logout} status={status} user={user} />
+      <Routes>
+        <Route path="/" element={<Home status={status} user={user} />} />
+        <Route path="/register" element={<Register />} />
+        <Route path="/login" element={<Login />} />
+        <Route path="/forgotpassword" element={<ForgotPassword />} />
+        <Route path="/verifyemail" element={<VerifyEmail />} />
+        <Route path="/pongpals" element={<PongPals />} />
+        <Route path="/settings" element={<Settings />} />
+        <Route path="/stats" element={<Stats />} />
+        <Route path="/mfa" element={<Mfa />} />
+        <Route path="*" element={<Navigate to="/" replace />} />
+        <Route
+          path="/stats/:anything"
+          element={<Navigate to="/stats" replace />}
+        />
+      </Routes>
+      <div className="flex justify-center my-4">
+        <button
+          className="border bg-teal-500 font-semibold hover:font-extrabold 
+					  hover:underline uppercase text-white p-4 mx-4 rounded-2xl"
+          onClick={showDatabase}
+        >
+          show Database (for dev use only)
+        </button>
+      </div>
     </>
-  )
-}
+  );
+};
 
 export default App;

--- a/frontend/react/src/App.tsx
+++ b/frontend/react/src/App.tsx
@@ -1,6 +1,5 @@
 import React from "react";
 import {
-  BrowserRouter as Router,
   Routes,
   Route,
   Navigate,
@@ -15,8 +14,7 @@ import Stats from "./pages/Stats";
 import VerifyEmail from "./pages/VerifyEmail";
 import showDatabase from "./components/showDatabase";
 import NavigationHeader from "./components/NavigationHeader";
-import { AuthContextType, User, useAuth } from "./auth/AuthProvider";
-import { useNavigate, Link } from "react-router-dom";
+import { useAuth } from "./auth/AuthProvider";
 import axios from "axios";
 import Mfa from "./pages/Mfa";
 import i18n from "./i18n";
@@ -45,37 +43,26 @@ const App: React.FC = () => {
   };
   const { status, user, refreshSession } = useAuth();
   return (
-    <>
-      <Router>
-        <NavigationHeader handleLogout={logout} status={status} user={user} />
-        <Routes>
-          <Route path="/" element={<Home status={status} user={user} />} />
-          <Route path="/register" element={<Register />} />
-          <Route path="/login" element={<Login />} />
-          <Route path="/forgotpassword" element={<ForgotPassword />} />
-          <Route path="/verifyemail" element={<VerifyEmail />} />
-          <Route path="/pongpals" element={<PongPals />} />
-          <Route path="/settings" element={<Settings />} />
-          <Route path="/stats" element={<Stats />} />
-          <Route path="/mfa" element={<Mfa />} />
-          <Route path="*" element={<Navigate to="/" replace />} />
-          <Route
-            path="/stats/:anything"
-            element={<Navigate to="/stats" replace />}
-          />
-        </Routes>
-        <div className="flex justify-center my-4">
-          <button
-            className="border bg-teal-500 font-semibold hover:font-extrabold 
-					  hover:underline uppercase text-white p-4 mx-4 rounded-2xl"
-            onClick={showDatabase}
-          >
-            show Database (for dev use only)
-          </button>
-        </div>
-      </Router>
+	<>
+		<NavigationHeader handleLogout={logout} status={status} user={user}/>
+		<Routes>
+			<Route path="/" element={<Home status={status} user={user}/>} />
+			<Route path="/register" element={<Register />} />
+			<Route path="/login" element={<Login />} />
+			<Route path="/forgotpassword" element={<ForgotPassword />} />
+			<Route path="/verifyemail" element={<VerifyEmail />} />
+			<Route path="/pongpals" element={<PongPals />} />
+			<Route path="/settings" element={<Settings />} />
+			<Route path="/stats" element={<Stats />} />
+			<Route path="/mfa" element={<Mfa />} />
+			<Route path="*" element={<Navigate to="/" replace/>} />
+			<Route path="/stats/:anything" element={<Navigate to="/stats" replace/>}/>
+		</Routes>
+		<div className="flex justify-center my-4"><button className="border bg-teal-500 font-semibold hover:font-extrabold 
+					  hover:underline uppercase text-white p-4 mx-4 rounded-2xl" 
+					  onClick={showDatabase}>show Database (for dev use only)</button></div>
     </>
-  );
-};
+  )
+}
 
 export default App;

--- a/frontend/react/src/api/axios.ts
+++ b/frontend/react/src/api/axios.ts
@@ -1,0 +1,1 @@
+import axios from 'axios';

--- a/frontend/react/src/api/axios.ts
+++ b/frontend/react/src/api/axios.ts
@@ -1,8 +1,8 @@
-import axios from 'axios';
+import axios from "axios";
 
 const api = axios.create({
-	baseURL: import.meta.env.VITE_API_BASE_URL || '/api',
-	withCredentials: true,
+  baseURL: import.meta.env.VITE_API_BASE_URL || "/api",
+  withCredentials: true,
 });
 
 export default api;

--- a/frontend/react/src/api/axios.ts
+++ b/frontend/react/src/api/axios.ts
@@ -1,1 +1,8 @@
 import axios from 'axios';
+
+const api = axios.create({
+	baseURL: import.meta.env.VITE_API_BASE_URL || '/api',
+	withCredentials: true,
+});
+
+export default api;

--- a/frontend/react/src/api/setupInterceptors.ts
+++ b/frontend/react/src/api/setupInterceptors.ts
@@ -1,45 +1,37 @@
-import { AxiosInstance } from 'axios';
-import { logoutFromInterceptor } from '../auth/AuthProvider';
+import { AxiosInstance } from "axios";
+import { logoutFromInterceptor } from "../auth/AuthProvider";
 
 let isHandlingSessionExpiry = false;
 
-const isSessionAuthFailure = (
-	status: number,
-  url: string,
-) : boolean => {
-    return (
-      (status === 401 || status === 419) &&
-      (
-        url.includes('/session') ||
-        url.includes('/users')
-      )
-    );
+const isSessionAuthFailure = (status: number, url: string): boolean => {
+  return (
+    (status === 401 || status === 419) &&
+    (url.includes("/session") || url.includes("/users"))
+  );
 };
 
-export function setupInterceptors({
-	api,
-}: {
-	api: AxiosInstance
-}) {
-	api.interceptors.response.use(
-		response => response,
-		async error => {
-			const status = error.response?.status;
-      const url = error.config?.url || '';
+export function setupInterceptors({ api }: { api: AxiosInstance }) {
+  api.interceptors.response.use(
+    (response) => response,
+    async (error) => {
+      const status = error.response?.status;
+      const url = error.config?.url || "";
 
-			if (!isHandlingSessionExpiry && isSessionAuthFailure(status, url)) {
-				isHandlingSessionExpiry = true;
-				console.warn(`Session expired (status: ${status}) on ${url} — refreshing session and redirecting`);
+      if (!isHandlingSessionExpiry && isSessionAuthFailure(status, url)) {
+        isHandlingSessionExpiry = true;
+        console.warn(
+          `Session expired (status: ${status}) on ${url} — refreshing session and redirecting`
+        );
 
-				logoutFromInterceptor?.(); // update context immediately
-				localStorage.removeItem('language');
+        logoutFromInterceptor?.(); // update context immediately
+        localStorage.removeItem("language");
 
-				// reset lock after short delay
-				setTimeout(() => {
-					isHandlingSessionExpiry = false;
-				}, 2000);
-			}
-			return Promise.reject(error);
-		}
-	);
+        // reset lock after short delay
+        setTimeout(() => {
+          isHandlingSessionExpiry = false;
+        }, 2000);
+      }
+      return Promise.reject(error);
+    }
+  );
 }

--- a/frontend/react/src/api/setupInterceptors.ts
+++ b/frontend/react/src/api/setupInterceptors.ts
@@ -1,0 +1,37 @@
+import { AxiosInstance } from 'axios';
+import { NavigateFunction } from 'react-router-dom';
+import { logoutFromInterceptor } from '../auth/AuthProvider';
+
+let isHandlingSessionExpiry = false;
+
+export function setupInterceptors({
+	api,
+	navigate,
+}: {
+	api: AxiosInstance
+	navigate: NavigateFunction;
+}) {
+	api.interceptors.response.use(
+		response => response,
+		async error => {
+			const status = error.response?.status;
+
+			if ((status === 401 || status === 419) && !isHandlingSessionExpiry) {
+				isHandlingSessionExpiry = true;
+				console.warn('Session expired (status:', status, ') — refreshing session and redirecting');
+
+				logoutFromInterceptor?.(); // update context immediately
+				localStorage.removeItem('language');
+
+				// avoid full reload
+				navigate('/login', { replace: true });
+
+				// reset lock after short delay
+				setTimeout(() => {
+					isHandlingSessionExpiry = false;
+				}, 2000);
+			}
+			return Promise.reject(error);
+		}
+	);
+}

--- a/frontend/react/src/auth/AuthProvider.tsx
+++ b/frontend/react/src/auth/AuthProvider.tsx
@@ -75,26 +75,32 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
 		refreshSession();
 	}, []);
 
+	/* Performs a session validity check for logged in users every 10 mins */
 	useEffect(() => {
 		if (status === 'authorized') {
 			const interval = setInterval(() => {
 				refreshSession();
-			}, /*10*/1 * 60 * 1000);
+			}, 10 * 60 * 1000);
 
 			return () => clearInterval(interval);
 		}
 	}, [status]);
 
+	/* Handles alerting user and redirect after session expiry */
 	useEffect(() => {
 		if (initialCheckComplete && sessionExpired) {
 			alert('Your session has expired. Please log in again.');
 			setSessionExpired(false);
+			navigate('/login', { replace: true });
 		}
-	}, [initialCheckComplete, sessionExpired]);
+	}, [initialCheckComplete, sessionExpired, navigate]);
 
+	/* After users session validity is checked for the first time, sets up interceptor for session validity handling */
 	useEffect(() => {
-		setupInterceptors({ api, navigate });
-	}, [refreshSession, navigate]);
+		if (initialCheckComplete) {
+			setupInterceptors({ api });
+		}
+	}, [initialCheckComplete, navigate]);
 
 	if (status === 'loading') {
 		return null;

--- a/frontend/react/src/auth/AuthProvider.tsx
+++ b/frontend/react/src/auth/AuthProvider.tsx
@@ -1,120 +1,124 @@
-import React, { createContext, useContext, useEffect, useState } from 'react';
-import { useNavigate } from 'react-router-dom';
-import { setupInterceptors } from '../api/setupInterceptors';
-import api from '../api/axios';
-import i18n from '../i18n';
+import React, { createContext, useContext, useEffect, useState } from "react";
+import { useNavigate } from "react-router-dom";
+import { setupInterceptors } from "../api/setupInterceptors";
+import api from "../api/axios";
+import i18n from "../i18n";
 
 export interface User {
-	id: string;
-	username: string;
-	email?: string;
-	profilePic?: string;
-	language?: string; 
+  id: string;
+  username: string;
+  email?: string;
+  profilePic?: string;
+  language?: string;
 }
 
 export interface AuthContextType {
-	status: 'loading' | 'authorized' | 'unauthorized';
-	user: User | null;
-	refreshSession: () => Promise<void>;
+  status: "loading" | "authorized" | "unauthorized";
+  user: User | null;
+  refreshSession: () => Promise<void>;
 }
 
 const AuthContext = createContext<AuthContextType | undefined>(undefined);
 
 export let logoutFromInterceptor: (() => void) | null = null; // export a hook
 
-export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
-	const [status, setStatus] = useState<'loading' | 'authorized' | 'unauthorized'>('loading');
-	const [user, setUser] = useState<User | null>(null);
-	const [sessionExpired, setSessionExpired] = useState(false);
-	const [initialCheckComplete, setInitialCheckComplete] = useState(false);
-	const navigate = useNavigate();
+export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({
+  children,
+}) => {
+  const [status, setStatus] = useState<
+    "loading" | "authorized" | "unauthorized"
+  >("loading");
+  const [user, setUser] = useState<User | null>(null);
+  const [sessionExpired, setSessionExpired] = useState(false);
+  const [initialCheckComplete, setInitialCheckComplete] = useState(false);
+  const navigate = useNavigate();
 
-	logoutFromInterceptor = () => {
-		setUser(null);
-		setStatus('unauthorized');
-		setSessionExpired(true);
-	};
+  logoutFromInterceptor = () => {
+    setUser(null);
+    setStatus("unauthorized");
+    setSessionExpired(true);
+  };
 
-	const refreshSession = async () => {
-		try {
-			const response = await api.get<User>('/session/user', {
-				headers: {
-					"Content-Type": "application/json", // optional but safe
-				},
-			});
-			const data = response.data;
-			
-			if (response.status === 200 && data?.id) {
-				const userLang = data.language ?? 'en';
-      			await i18n.changeLanguage(userLang);
-      			localStorage.setItem('language', userLang);
+  const refreshSession = async () => {
+    try {
+      const response = await api.get<User>("/session/user", {
+        headers: {
+          "Content-Type": "application/json", // optional but safe
+        },
+      });
+      const data = response.data;
 
-        		setUser(data);
-        		setStatus('authorized');
-				setSessionExpired(false);
-      		} else {
-				setUser(null);
-				setStatus('unauthorized');
-				await i18n.changeLanguage('en');
-				localStorage.removeItem('language');
-			}
-		} catch (error) {
-			if (status === 'authorized') {
-				setSessionExpired(true);
-			}
-			setUser(null);
-			setStatus('unauthorized');
-			await i18n.changeLanguage('en');
-			localStorage.removeItem('language');
-		} finally {
-			setInitialCheckComplete(true);
-		}
-	};
+      if (response.status === 200 && data?.id) {
+        const userLang = data.language ?? "en";
+        await i18n.changeLanguage(userLang);
+        localStorage.setItem("language", userLang);
 
-	useEffect(() => {
-		refreshSession();
-	}, []);
+        setUser(data);
+        setStatus("authorized");
+        setSessionExpired(false);
+      } else {
+        setUser(null);
+        setStatus("unauthorized");
+        await i18n.changeLanguage("en");
+        localStorage.removeItem("language");
+      }
+    } catch (error) {
+      if (status === "authorized") {
+        setSessionExpired(true);
+      }
+      setUser(null);
+      setStatus("unauthorized");
+      await i18n.changeLanguage("en");
+      localStorage.removeItem("language");
+    } finally {
+      setInitialCheckComplete(true);
+    }
+  };
 
-	/* Performs a session validity check for logged in users every 10 mins */
-	useEffect(() => {
-		if (status === 'authorized') {
-			const interval = setInterval(() => {
-				refreshSession();
-			}, 10 * 60 * 1000);
+  useEffect(() => {
+    refreshSession();
+  }, []);
 
-			return () => clearInterval(interval);
-		}
-	}, [status]);
+  /* Performs a session validity check for logged in users every 10 mins */
+  useEffect(() => {
+    if (status === "authorized") {
+      const interval = setInterval(() => {
+        refreshSession();
+      }, 10 * 60 * 1000);
 
-	/* Handles alerting user and redirect after session expiry */
-	useEffect(() => {
-		if (initialCheckComplete && sessionExpired) {
-			alert('Your session has expired. Please log in again.');
-			setSessionExpired(false);
-			navigate('/login', { replace: true });
-		}
-	}, [initialCheckComplete, sessionExpired, navigate]);
+      return () => clearInterval(interval);
+    }
+  }, [status]);
 
-	/* After users session validity is checked for the first time, sets up interceptor for session validity handling */
-	useEffect(() => {
-		if (initialCheckComplete) {
-			setupInterceptors({ api });
-		}
-	}, [initialCheckComplete, navigate]);
+  /* Handles alerting user and redirect after session expiry */
+  useEffect(() => {
+    if (initialCheckComplete && sessionExpired) {
+      alert("Your session has expired. Please log in again.");
+      setSessionExpired(false);
+      navigate("/login", { replace: true });
+    }
+  }, [initialCheckComplete, sessionExpired, navigate]);
 
-	if (status === 'loading') {
-		return null;
-	}
+  /* After users session validity is checked for the first time, sets up interceptor for session validity handling */
+  useEffect(() => {
+    if (initialCheckComplete) {
+      setupInterceptors({ api });
+    }
+  }, [initialCheckComplete, navigate]);
 
-	return (
-		<AuthContext.Provider value={{ status, user, refreshSession }}>
-			{children}
-		</AuthContext.Provider>
-	);
+  if (status === "loading") {
+    return null;
+  }
+
+  return (
+    <AuthContext.Provider value={{ status, user, refreshSession }}>
+      {children}
+    </AuthContext.Provider>
+  );
 };
 
 export const useAuth = () => {
-	const context = useContext(AuthContext);
-	if (!context) throw new Error('useAuth must be used within AuthProvider');
-	return context;
+  const context = useContext(AuthContext);
+  if (!context) throw new Error("useAuth must be used within AuthProvider");
+  return context;
 };

--- a/frontend/react/src/components/BefriendButton.tsx
+++ b/frontend/react/src/components/BefriendButton.tsx
@@ -1,121 +1,94 @@
-import React, { useEffect, useState } from "react";
-import axios from "axios";
-import { useTranslation } from "react-i18next";
-
-const apiUrl = import.meta.env.VITE_API_BASE_URL || "/api";
+import React, { useEffect, useState } from 'react';
+import api from '../api/axios';
+import { useTranslation } from 'react-i18next';
 
 interface BefriendButtonProps {
-  currentUserId: string;
-  viewedUserId: string;
+	currentUserId: string;
+	viewedUserId: string;
 }
 
-const BefriendButton: React.FC<BefriendButtonProps> = ({
-  currentUserId,
-  viewedUserId,
-}) => {
-  const [isFriend, setIsFriend] = useState(false);
-  const [friendRequestSent, setFriendRequestSent] = useState(false);
-  const { t } = useTranslation();
+const BefriendButton: React.FC<BefriendButtonProps> = ({ currentUserId, viewedUserId }) => {
+	const [isFriend, setIsFriend] = useState(false);
+	const [friendRequestSent, setFriendRequestSent] = useState(false);
+	const { t } = useTranslation();
 
-  useEffect(() => {
-    const checkFriendStatus = async () => {
-      if (currentUserId === viewedUserId) return;
-      try {
-        const res = await axios.get(apiUrl + "/friend-status", {
-          params: {
-            userId1: currentUserId,
-            userId2: viewedUserId,
-          },
-          headers: {
-            "Content-Type": "application/json", // optional but safe
-          },
-          withCredentials: true,
-        });
-        setIsFriend(res.data.isFriend);
-        setFriendRequestSent(res.data.requestPending);
-      } catch (error) {
-        console.error("Failed to check friend status", error);
-      }
-    };
+	useEffect(() => {
 
-    checkFriendStatus();
-  }, [currentUserId, viewedUserId]);
+		const checkFriendStatus = async () => {
+			if (currentUserId === viewedUserId) return;
+			try {
+				const res = await api.get('/friend-status', {
+					params: {
+						userId1: currentUserId,
+						userId2: viewedUserId,
+					},
+					headers: {
+						"Content-Type": "application/json", // optional but safe
+					},
+				});
+				setIsFriend(res.data.isFriend);
+				setFriendRequestSent(res.data.requestPending);
+			} catch (error) {
+				console.error('Failed to check friend status', error);
+			}
+		};
 
-  const handleSendFriendRequest = async () => {
-    try {
-      await axios.post(
-        apiUrl + "/friend-request",
-        {
-          receiverId: viewedUserId,
-        },
-        {
-          headers: {
-            "Content-Type": "application/json",
-          },
-          withCredentials: true,
-        }
-      );
-      setFriendRequestSent(true);
-    } catch (error) {
-      console.error("Failed to send friend request", error);
-    }
-  };
+		checkFriendStatus();
+	}, [currentUserId, viewedUserId]);
 
-  const handleUnfriend = async () => {
-    try {
-      await axios.post(
-        apiUrl + "/unfriend",
-        {
-          userId1: currentUserId,
-          userId2: viewedUserId,
-        },
-        {
-          headers: {
-            "Content-Type": "application/json",
-          },
-          withCredentials: true,
-        }
-      );
-      setIsFriend(false);
-    } catch (error) {
-      console.error("Failed to unfriend user", error);
-    }
-  };
 
-  if (currentUserId === viewedUserId) return null;
+	const handleSendFriendRequest = async () => {
+		try {
+			await api.post('/friend-request', {
+				receiverId: viewedUserId,
+			}, { headers: { "Content-Type": "application/json" },
+			});
+			setFriendRequestSent(true);
+		} catch (error) {
+			console.error('Failed to send friend request', error);
+		}
+	};
 
-  if (isFriend) {
-    return (
-      <button
-        className="block mx-auto px-17 text-white bg-teal-700 hover:bg-teal-800 focus:ring-4 
+	const handleUnfriend = async () => {
+		try {
+			await api.post('/unfriend', {
+				userId1: currentUserId,
+				userId2: viewedUserId,
+			}, { headers: { "Content-Type": "application/json" },
+			});
+			setIsFriend(false);
+		} catch (error) {
+			console.error('Failed to unfriend user', error);
+		}
+	};
+
+	if (currentUserId === viewedUserId) return null;
+
+	if (isFriend) {
+		return (
+			<button
+				className="block mx-auto px-17 text-white bg-teal-700 hover:bg-teal-800 focus:ring-4 
 				focus:outline-none focus:ring-blue-300 font-semibold rounded-lg text-sm w-full 
 				sm:w-auto py-2.5 text-center dark:bg-teal-600 dark:hover:bg-teal-700
 				dark:focus:ring-teal-800 m-5"
-        onClick={handleUnfriend}
-      >
-        {t("befriendButton.unfriend")}
-      </button>
-    );
-  }
+				onClick={handleUnfriend}>
+					{t('befriendButton.unfriend')}
+			</button>
+		);
+	}
+		
+	if (friendRequestSent) return <p className="text-4xl text-center text-teal-800 dark:text-teal-300 m-3">{t('befriendButton.friend_request_pending')}</p>;
 
-  if (friendRequestSent)
-    return (
-      <p className="text-4xl text-center text-teal-800 dark:text-teal-300 m-3">
-        {t("befriendButton.friend_request_pending")}
-      </p>
-    );
-
-  return (
-    <button
-      className="block mx-auto px-17 text-white bg-teal-700 hover:bg-teal-800 focus:ring-4 
+	return (
+		<button 
+			className="block mx-auto px-17 text-white bg-teal-700 hover:bg-teal-800 focus:ring-4 
 			focus:outline-none focus:ring-blue-300 font-semibold rounded-lg text-sm w-full 
 			sm:w-auto py-2.5 text-center dark:bg-teal-600 dark:hover:bg-teal-700
 			dark:focus:ring-teal-800 m-5"
-      onClick={handleSendFriendRequest}
-    >
-      {t("befriendButton.befriend")}
-    </button>
-  );
+			onClick={handleSendFriendRequest}>
+				{t('befriendButton.befriend')}
+		</button>
+	);
 };
 
 export default BefriendButton;

--- a/frontend/react/src/components/ConfirmOtpField.tsx
+++ b/frontend/react/src/components/ConfirmOtpField.tsx
@@ -1,10 +1,9 @@
-import react from "react";
-import axios from "axios";
+import api from '../api/axios';
 import React, { useState } from "react";
 import { useTranslation } from "react-i18next";
 
 interface Props {
-  apiUrl: string;
+  apiUrl: string; // clean this up
   otp: string;
   setOtp: (otp: string) => void;
   setIs2FAEnabled: (isEnabled: boolean) => void;
@@ -12,7 +11,7 @@ interface Props {
 }
 
 const ConfirmOtpField: React.FC<Props> = ({
-  apiUrl,
+  apiUrl, // clean this up
   otp,
   setOtp,
   setIs2FAEnabled,
@@ -31,19 +30,15 @@ const ConfirmOtpField: React.FC<Props> = ({
     try {
       // send request to backend to verify OTP
       console.log("Verifying OTP:", otp);
-      const response = await axios.post(
-        apiUrl + "/auth/otp/verify",
+      const response = await api.post("/auth/otp/verify",
         { code: otp },
-        { withCredentials: true }
       );
       if (response.status === 200) {
         // OTP verified successfully, enable 2FA
         setIs2FAEnabled(true);
         setOtp("");
-        axios.post(
-          apiUrl + "/users/emailActivation",
+        api.post("/users/emailActivation",
           { emailVerified: true },
-          { withCredentials: true }
         );
         axios.post(
           apiUrl + "/auth/mfa",

--- a/frontend/react/src/components/ConfirmOtpField.tsx
+++ b/frontend/react/src/components/ConfirmOtpField.tsx
@@ -3,7 +3,6 @@ import React, { useState } from "react";
 import { useTranslation } from "react-i18next";
 
 interface Props {
-  apiUrl: string; // clean this up
   otp: string;
   setOtp: (otp: string) => void;
   setIs2FAEnabled: (isEnabled: boolean) => void;
@@ -11,7 +10,6 @@ interface Props {
 }
 
 const ConfirmOtpField: React.FC<Props> = ({
-  apiUrl, // clean this up
   otp,
   setOtp,
   setIs2FAEnabled,

--- a/frontend/react/src/components/ConfirmOtpField.tsx
+++ b/frontend/react/src/components/ConfirmOtpField.tsx
@@ -38,10 +38,9 @@ const ConfirmOtpField: React.FC<Props> = ({
         api.post("/users/emailActivation",
           { emailVerified: true },
         );
-        axios.post(
-          apiUrl + "/auth/mfa",
+        api.post(
+          "/auth/mfa",
           { mfaInUse: true },
-          { withCredentials: true }
         );
         setIsError(false);
         setMessage(t("confirmOtp.email_verified_success"));

--- a/frontend/react/src/components/FriendList.tsx
+++ b/frontend/react/src/components/FriendList.tsx
@@ -1,9 +1,7 @@
-import React, { useEffect, useState } from "react";
+import React from "react";
 import { Link } from "react-router-dom";
 import { Friend } from "../types/friend";
 import { useTranslation } from "react-i18next";
-
-const apiUrl = import.meta.env.VITE_API_BASE_URL || "api";
 
 type FriendListProps = {
   friends: Friend[];

--- a/frontend/react/src/components/MatchHistory.tsx
+++ b/frontend/react/src/components/MatchHistory.tsx
@@ -1,8 +1,6 @@
-import React, { useEffect, useState } from "react";
-import axios from "axios";
-import { useTranslation } from "react-i18next";
-
-const apiUrl = import.meta.env.VITE_API_BASE_URL || "/api";
+import React, { useEffect, useState } from 'react';
+import api from '../api/axios';
+import { useTranslation } from 'react-i18next';
 
 interface MatchHistoryItem {
   date: string;
@@ -28,31 +26,26 @@ const MatchHistory: React.FC<MatchHistoryProps> = ({ userId }) => {
   const [loading, setLoading] = useState<boolean>(true);
   const [error, setError] = useState<string | null>(null);
 
-  useEffect(() => {
-    const fetchStats = async () => {
-      try {
-        const response = await axios.get(apiUrl + `/stats/${userId}`, {
-          headers: {
-            "Content-Type": "application/json", // optional but safe
-          },
-          withCredentials: true,
-        });
-        const data = response.data;
-        setStats({
-          totalWins: data.totalWins || 0,
-          totalLosses: data.totalLosses || 0,
-          totalTournamentsWon: data.totalTournamentsWon || 0,
-          matchHistory: Array.isArray(data.matchHistory)
-            ? data.matchHistory
-            : [],
-        });
-      } catch (error) {
-        console.error(error);
-        setError(t("matchHistory.errorFetching"));
-      } finally {
-        setLoading(false);
-      }
-    };
+	useEffect(() => {
+		const fetchStats = async () => {
+			try {
+				const response = await api.get(`/stats/${userId}`, {
+					headers: { "Content-Type": "application/json" },
+				});
+				const data = response.data;
+				setStats({
+					totalWins: data.totalWins || 0,
+					totalLosses: data.totalLosses || 0,
+					totalTournamentsWon: data.totalTournamentsWon || 0,
+					matchHistory: Array.isArray(data.matchHistory) ? data.matchHistory : [], 
+				});
+			} catch (error) {
+				console.error(error);
+				setError(t('matchHistory.errorFetching'));
+			} finally {
+				setLoading(false);
+			}
+		};
 
     if (userId) fetchStats();
   }, [userId, t]);

--- a/frontend/react/src/components/PendingRequests.tsx
+++ b/frontend/react/src/components/PendingRequests.tsx
@@ -1,9 +1,7 @@
 import React, { useEffect, useState } from "react";
-import axios from "axios";
-import { Friend } from "../types/friend";
-import { useTranslation } from "react-i18next";
-
-const apiUrl = import.meta.env.VITE_API_BASE_URL || "api";
+import api from '../api/axios';
+import { Friend } from '../types/friend';
+import { useTranslation } from 'react-i18next';
 
 type Request = {
   id: number;
@@ -24,41 +22,32 @@ export const PendingRequests: React.FC<Props> = ({ userId, onFriendAdded }) => {
   const [message, setMessage] = useState<string | null>(null);
   const { t } = useTranslation();
 
-  useEffect(() => {
-    const fetchRequests = async () => {
-      try {
-        const response = await axios.get(apiUrl + `/users/${userId}/requests`, {
-          headers: {
-            "Content-Type": "application/json", // optional but safe
-          },
-          withCredentials: true,
-        });
-        setRequests(response.data);
-      } catch (error) {
-        console.error("Failed to fetch requests:", error);
-      }
-    };
+	useEffect(() => {
+		const fetchRequests = async () => {
+			try {
+				const response = await api.get(`/users/${userId}/requests`, {
+					headers: { "Content-Type": "application/json" },
+				});
+				setRequests(response.data);
+			} catch (error) {
+				console.error('Failed to fetch requests:', error);
+			}
+		};
 
     fetchRequests();
   }, [userId]);
 
-  const handleAction = async (
-    requestId: number,
-    username: string,
-    senderId: string,
-    action: "accept" | "decline"
-  ) => {
-    try {
-      await axios.post(
-        apiUrl + `/friends/${action}`,
-        { requestId },
-        {
-          headers: {
-            "Content-Type": "application/json",
-          },
-          withCredentials: true,
-        }
-      );
+	const handleAction = async (
+		requestId: number,
+		username: string,
+		senderId: string,
+		action: "accept" | "decline"
+	) => {
+		try {
+			await api.post(`/friends/${action}`,
+				{ requestId },
+				{ headers: { "Content-Type": "application/json" } },
+			);
 
       setRequests((prev) => prev.filter((r) => r.id !== requestId));
       if (action === "accept") {

--- a/frontend/react/src/components/PlayerRegistrationBox.tsx
+++ b/frontend/react/src/components/PlayerRegistrationBox.tsx
@@ -1,46 +1,40 @@
-import React, { useState } from "react";
-import axios from "axios";
-import { useTranslation } from "react-i18next";
+import React, { useState } from 'react';
+import api from '../api/axios';
+import { useTranslation } from 'react-i18next';
 
 interface PlayerBoxProps {
   label: string;
   onRegister: (player: { username: string; isGuest: boolean }) => void;
 }
 
-const apiUrl = import.meta.env.VITE_API_BASE_URL || "/api";
-
 const PlayerRegistrationBox: React.FC<PlayerBoxProps> = ({
   label,
-  onRegister,
+  onRegister
 }) => {
-  const [username, setUsername] = useState("");
-  const [password, setPassword] = useState("");
-  const [error, setError] = useState("");
+  const [username, setUsername] = useState('');
+  const [password, setPassword] = useState('');
+  const [error, setError] = useState('');
   const { t } = useTranslation();
 
-  const handleSubmit = async (e: React.FormEvent) => {
-    e.preventDefault();
-    if (!username) {
-      setError(t("playerBox.usernameRequired"));
-      return;
+const handleSubmit = async (e: React.FormEvent) => {
+  e.preventDefault();
+  if (!username) {
+    setError(t('playerBox.usernameRequired'));
+    return;
+  }
+  if (!password) {
+    // Guest registration: allow any alias, no backend check
+    onRegister({ username, isGuest: true });
+  } else {
+    // Registered user login
+    try {
+      await api.post('/auth/login', { username, password });
+      onRegister({ username, isGuest: false });
+    } catch {
+      setError(t('playerBox.loginFailed'));
     }
-    if (!password) {
-      // Guest registration: allow any alias, no backend check
-      onRegister({ username, isGuest: true });
-    } else {
-      // Registered user login
-      try {
-        await axios.post(
-          apiUrl + "/auth/login",
-          { username, password },
-          { withCredentials: true }
-        );
-        onRegister({ username, isGuest: false });
-      } catch {
-        setError(t("playerBox.loginFailed"));
-      }
-    }
-  };
+  }
+};
 
   return (
     <form

--- a/frontend/react/src/components/PongGame.tsx
+++ b/frontend/react/src/components/PongGame.tsx
@@ -1,10 +1,9 @@
-import axios from "axios";
-import React, { useRef, useEffect, useState } from "react";
+import api from '../api/axios';
+import React, { useRef, useEffect, useState } from 'react';
 
-const paddleSound = new Audio("../../assets/paddle.mp3");
-const scoreSound = new Audio("../../assets/score.mp3");
-const wallSound = new Audio("../../assets/wall.mp3");
-const apiUrl = import.meta.env.VITE_API_BASE_URL || "/api";
+const paddleSound = new Audio('../../assets/paddle.mp3');
+const scoreSound = new Audio('../../assets/score.mp3');
+const wallSound = new Audio('../../assets/wall.mp3');
 
 interface PongGameProps {
   player1: { username: string; isGuest: boolean };
@@ -281,16 +280,15 @@ const PongGame: React.FC<PongGameProps> = ({ player1, player2 }) => {
         setWinner(leftScore === 11 ? player1.username : player2.username);
         setScore({ left: leftScore, right: rightScore });
         gameOver = true;
-        axios
-          .post(apiUrl + "/matches", {
-            player: player1.isGuest ? "guest" : player1.username,
-            opponent: player2.isGuest ? "guest" : player2.username,
-            winner: leftScore === 11 ? player1.username : player2.username,
-            loser: leftScore === 11 ? player2.username : player1.username,
-            leftScore,
-            rightScore,
-          })
-          .catch(console.error);
+		api.post('/matches', {
+			player: player1.isGuest ? 'guest' : player1.username,
+			opponent: player2.isGuest ? 'guest' : player2.username,
+			winner: leftScore === 11 ? player1.username : player2.username,
+			loser: leftScore === 11 ? player2.username : player1.username,
+			leftScore,
+			rightScore,
+		})
+    .catch(console.error);
       }
     }
 

--- a/frontend/react/src/components/SearchPals.tsx
+++ b/frontend/react/src/components/SearchPals.tsx
@@ -1,10 +1,8 @@
-import React, { useState, useEffect } from "react";
-import { Link } from "react-router-dom";
-import { useAuth } from "../auth/AuthProvider";
-import axios from "axios";
-import { useTranslation } from "react-i18next";
-
-const apiUrl = import.meta.env.VITE_API_BASE_URL || "api";
+import React, { useState, useEffect } from 'react';
+import { Link } from 'react-router-dom';
+import { useAuth } from '../auth/AuthProvider';
+import api from '../api/axios';
+import { useTranslation } from 'react-i18next';
 
 interface User {
   id: number;
@@ -40,27 +38,26 @@ const SearchPals: React.FC = () => {
 
       setError(null);
 
-      const searchUsers = async () => {
-        try {
-          const response = await axios.get(apiUrl + "/users/search", {
-            params: {
-              query: trimmed,
-              excludeUserId: user?.id,
-            },
-            headers: {
-              "Content-Type": "application/json", // optional but safe
-            },
-            withCredentials: true,
-          });
-          const data = response.data;
-          setResults(Array.isArray(data) ? data : []);
-          setHasSearched(true);
-        } catch (error) {
-          console.error("Search failed:", error);
-          setError(t("searchPals.errorSearchFailed"));
-          setHasSearched(false);
-        }
-      };
+			const searchUsers = async () => {
+				try {
+					const response = await api.get('/users/search',
+						{
+							params: {
+								query: trimmed,
+								excludeUserId: user?.id,
+							},
+							headers: { "Content-Type": "application/json" },
+						}
+					);
+					const data = response.data;
+					setResults(Array.isArray(data) ? data : []);
+					setHasSearched(true);
+				} catch (error) {
+					console.error('Search failed:', error);
+					setError(t('searchPals.errorSearchFailed'));
+					setHasSearched(false);
+				}
+			};
 
       searchUsers();
     }, 300); // debounce for smoother UX

--- a/frontend/react/src/components/SettingsField.tsx
+++ b/frontend/react/src/components/SettingsField.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect, useRef } from "react";
-import api from '../api/axios';
+import api from "../api/axios";
 import { useTranslation } from "react-i18next";
 
 interface FieldProps {
@@ -91,12 +91,12 @@ const SettingsField: React.FC<FieldProps> = ({
       return;
     }
 
-		try {
-			const endpoint = type === "email" ? "/user/email" : "/user/password";
-			await api.put(endpoint, {
-				newValue: inputValue.trim(),
-				currentPassword: currentPassword.trim(),
-			});
+    try {
+      const endpoint = type === "email" ? "/user/email" : "/user/password";
+      await api.put(endpoint, {
+        newValue: inputValue.trim(),
+        currentPassword: currentPassword.trim(),
+      });
 
       setSuccess(t("settings.updateSuccess", { label }));
       setError(null);

--- a/frontend/react/src/components/SettingsField.tsx
+++ b/frontend/react/src/components/SettingsField.tsx
@@ -1,8 +1,6 @@
 import React, { useState, useEffect, useRef } from "react";
-import axios from "axios";
+import api from '../api/axios';
 import { useTranslation } from "react-i18next";
-
-const apiUrl = import.meta.env.VITE_API_BASE_URL || "api";
 
 interface FieldProps {
   label: string;
@@ -93,17 +91,12 @@ const SettingsField: React.FC<FieldProps> = ({
       return;
     }
 
-    try {
-      const endpoint =
-        type === "email" ? apiUrl + "/user/email" : apiUrl + "/user/password";
-      await axios.put(
-        endpoint,
-        {
-          newValue: inputValue.trim(),
-          currentPassword: currentPassword.trim(),
-        },
-        { withCredentials: true }
-      );
+		try {
+			const endpoint = type === "email" ? "/user/email" : "/user/password";
+			await api.put(endpoint, {
+				newValue: inputValue.trim(),
+				currentPassword: currentPassword.trim(),
+			});
 
       setSuccess(t("settings.updateSuccess", { label }));
       setError(null);

--- a/frontend/react/src/components/StatsHeader.tsx
+++ b/frontend/react/src/components/StatsHeader.tsx
@@ -1,6 +1,6 @@
-import React from "react";
-import { useNavigate } from "react-router-dom";
-import { useTranslation } from "react-i18next";
+import React from 'react';
+import { useNavigate } from 'react-router-dom';
+import { useTranslation } from 'react-i18next';
 
 interface StatsHeaderProps {
   username: string;

--- a/frontend/react/src/main.tsx
+++ b/frontend/react/src/main.tsx
@@ -1,9 +1,9 @@
-import { StrictMode } from "react";
-import { createRoot } from "react-dom/client";
-import "./index.css";
-import App from "./App.tsx";
-import { AuthProvider } from "./auth/AuthProvider.tsx";
-import "./i18n";
+import { StrictMode } from 'react'
+import { createRoot } from 'react-dom/client'
+import './index.css'
+import App from './App.tsx'
+import { AuthProvider } from './auth/AuthProvider.tsx'
+import './i18n';
 
 createRoot(document.getElementById("root")!).render(
   <StrictMode>

--- a/frontend/react/src/main.tsx
+++ b/frontend/react/src/main.tsx
@@ -2,13 +2,16 @@ import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
 import './index.css'
 import App from './App.tsx'
+import { BrowserRouter } from 'react-router-dom';
 import { AuthProvider } from './auth/AuthProvider.tsx'
 import './i18n';
 
 createRoot(document.getElementById("root")!).render(
   <StrictMode>
-    <AuthProvider>
-      <App />
-    </AuthProvider>
+    <BrowserRouter>
+      <AuthProvider>
+        <App />
+      </AuthProvider>
+    </BrowserRouter>
   </StrictMode>
 );

--- a/frontend/react/src/main.tsx
+++ b/frontend/react/src/main.tsx
@@ -1,10 +1,10 @@
-import { StrictMode } from 'react'
-import { createRoot } from 'react-dom/client'
-import './index.css'
-import App from './App.tsx'
-import { BrowserRouter } from 'react-router-dom';
-import { AuthProvider } from './auth/AuthProvider.tsx'
-import './i18n';
+import { StrictMode } from "react";
+import { createRoot } from "react-dom/client";
+import "./index.css";
+import App from "./App.tsx";
+import { BrowserRouter } from "react-router-dom";
+import { AuthProvider } from "./auth/AuthProvider.tsx";
+import "./i18n";
 
 createRoot(document.getElementById("root")!).render(
   <StrictMode>

--- a/frontend/react/src/pages/Login.tsx
+++ b/frontend/react/src/pages/Login.tsx
@@ -1,10 +1,8 @@
-import React, { useState, useEffect } from "react";
-import { useNavigate, Link, useLocation } from "react-router-dom";
-import axios from "axios";
-import { useAuth } from "../auth/AuthProvider";
-import i18n from "../i18n";
-
-const apiUrl = import.meta.env.VITE_API_BASE_URL || "api";
+import React, { useState, useEffect } from 'react';
+import { useNavigate, Link } from 'react-router-dom';
+import api from '../api/axios';
+import { useAuth } from '../auth/AuthProvider';
+import i18n from '../i18n';
 
 const MAX_ATTEMPTS = 5;
 const COOLDOWN_SECONDS = 30;
@@ -21,32 +19,22 @@ const isValidPassword = (password: string) => {
 };
 
 const Login: React.FC = () => {
-  const [username, setUsername] = useState("");
-  const [password, setPassword] = useState("");
-  const [error, setError] = useState<string | null>(null);
-  const [attempts, setAttempts] = useState(0);
-  const [cooldown, setCooldown] = useState(0);
-  //const [sessionExpired, setSessionExpired] = useState(false);
+	const [username, setUsername] = useState('');
+	const [password, setPassword] = useState('');
+	const [error, setError] = useState<string | null>(null);
+	const [attempts, setAttempts] = useState(0);
+	const [cooldown, setCooldown] = useState(0);
 
-  const navigate = useNavigate();
-  //const location = useLocation();
-  const { status, refreshSession } = useAuth();
+	const navigate = useNavigate();
+	const { status, refreshSession } = useAuth();
 
-  /* useEffect(() => {
-		// check for "reason=expired" in URL query params
-		const params = new URLSearchParams(location.search);
-		if (params.get('reason') === 'expired') {
-			setSessionExpired(true);
+	useEffect(() => {
+		let timer: ReturnType<typeof setTimeout>;
+		if (cooldown > 0) {
+			timer = setTimeout(() => setCooldown(cooldown - 1), 1000);
 		}
-	}, [location.search]); */
-
-  useEffect(() => {
-    let timer: ReturnType<typeof setTimeout>;
-    if (cooldown > 0) {
-      timer = setTimeout(() => setCooldown(cooldown - 1), 1000);
-    }
-    return () => clearTimeout(timer);
-  }, [cooldown]);
+		return () => clearTimeout(timer);
+	}, [cooldown]);
 
   useEffect(() => {
     if (status === "authorized") {
@@ -77,18 +65,11 @@ const Login: React.FC = () => {
 			return;
 		} */
 
-    let response;
-    try {
-      response = await axios.post(
-        apiUrl + "/users/login",
-        { username, password },
-        {
-          headers: {
-            "Content-Type": "application/json",
-          },
-          withCredentials: true,
-        }
-      );
+		let response
+		try {
+			response = await api.post('/users/login', { username, password }, {
+					headers: { "Content-Type": "application/json" }
+			});
 
       const data = response.data;
       const userLang = response.data.language ?? "en";
@@ -132,51 +113,30 @@ const Login: React.FC = () => {
 
   return (
     <div className="text-center max-w-2xl dark:bg-black bg-white mx-auto rounded-lg">
-      <h1 className="text-6xl text-center text-teal-800 dark:text-teal-300 m-5 p-5">
-        Player Login
-      </h1>
-      {/*{sessionExpired && (
-		<p className="text-red-600 font-bold mb-4">
-			Your session has expired. Please log in again.
-		</p>
-	  )}*/}
-      <form
-        className="max-w-sm mx-auto"
-        onSubmit={handleLogin}
-        autoComplete="off"
-      >
-        <div className="mb-5">
-          <label className={labelStyles} htmlFor="username">
-            Username:
-          </label>
-          <input
-            className={inputStyles}
-            type="text"
-            id="username"
-            placeholder="Username"
-            value={username}
-            onChange={(e) => setUsername(e.target.value)}
-            autoComplete="username"
-            disabled={cooldown > 0}
-          />
-        </div>
-        <div className="mb-5">
-          <label className={labelStyles} htmlFor="password">
-            Password:
-          </label>
-          <input
-            className={inputStyles}
-            type="password"
-            id="password"
-            placeholder="Password"
-            value={password}
-            onChange={(e) => setPassword(e.target.value)}
-            autoComplete="current-password"
-            disabled={cooldown > 0}
-          />
-        </div>
-        <button
-          className="block mx-auto my-5 px-20 text-white bg-teal-700 hover:bg-teal-800 focus:ring-4 
+      <h1 className="text-6xl text-center text-teal-800 dark:text-teal-300 m-5 p-5">Player Login</h1>
+	  <form className="max-w-sm mx-auto" onSubmit={handleLogin} autoComplete="off">
+	  <div className="mb-5"><label className={labelStyles} htmlFor="username">Username:</label>
+	  <input className={inputStyles}
+          type="text"
+		  id="username"
+          placeholder="Username"
+		  value={username}
+		  onChange={(e) => setUsername(e.target.value)}
+		  autoComplete="username"
+		  disabled={cooldown > 0}
+        /></div>
+		<div className="mb-5">
+		<label className={labelStyles} htmlFor="password">Password:</label>
+        <input className={inputStyles}
+          type="password"
+		  id="password"
+          placeholder="Password"
+		  value={password}
+		  onChange={(e) => setPassword(e.target.value)}
+		  autoComplete="current-password"
+		  disabled={cooldown > 0}
+        /></div>
+        <button className="block mx-auto my-5 px-20 text-white bg-teal-700 hover:bg-teal-800 focus:ring-4 
 								  focus:outline-none focus:ring-blue-300 font-semibold rounded-lg text-sm w-full 
 								  sm:w-auto py-2.5 text-center dark:bg-teal-600 dark:hover:bg-teal-700
 								  dark:focus:ring-teal-800"

--- a/frontend/react/src/pages/Mfa.tsx
+++ b/frontend/react/src/pages/Mfa.tsx
@@ -1,11 +1,10 @@
 import React, { useEffect, useState, useRef } from "react";
 import { useNavigate } from "react-router-dom";
-import axios from "axios";
+import api from '../api/axios';
+import { isAxiosError } from "axios";
 import { useAuth } from "../auth/AuthProvider";
 import { useTranslation } from "react-i18next";
 import i18n from "../i18n"; // make sure this is imported
-
-const apiUrl = import.meta.env.VITE_API_BASE_URL || "api";
 
 const Mfa: React.FC = () => {
   const [code, setCode] = useState("");
@@ -47,28 +46,22 @@ const Mfa: React.FC = () => {
     setIsLoading(true);
 
     try {
-      const response = await axios.post(
-        apiUrl + "/auth/verify-otp",
+      const response = await api.post("/auth/verify-otp",
         { code },
-        {
-          headers: {
-            "Content-Type": "application/json",
-          },
-          withCredentials: true,
-        }
+        { headers: { "Content-Type": "application/json" } },
       );
       if (response.status === 200) {
         await refreshSession();
         navigate("/");
       }
     } catch (error) {
-      if (axios.isAxiosError(error) && error.response) {
+      if (isAxiosError(error) && error.response) {
         if (error.response.status === 401) {
-          setError(t("mfa.invalidOtp"));
+        setError(t("mfa.invalidOtp"));
         } else if (error.response.status === 403) {
-          setError(t("mfa.otpExpired"));
+        setError(t("mfa.otpExpired"));
         } else {
-          setError(t("mfa.tryAgainError"));
+        setError(t("mfa.tryAgainError"));
         }
       } else {
         setError(t("mfa.generalError"));
@@ -82,18 +75,14 @@ const Mfa: React.FC = () => {
     setError(null);
     setIsLoading(true);
     try {
-      const response = await axios.get(apiUrl + "/auth/otp-wait-time", {
-        withCredentials: true,
-      });
+      const response = await api.get("/auth/otp-wait-time");
       const waitTime = response.data.secondsLeft;
 
       if (waitTime > 0) {
         setError(t("mfa.waitTime", { count: waitTime }));
       } else {
-        await axios.post(
-          apiUrl + "/auth/resend-otp",
+        await api.post("/auth/resend-otp",
           {},
-          { withCredentials: true }
         );
         setError(t("mfa.otpResent"));
       }

--- a/frontend/react/src/pages/Mfa.tsx
+++ b/frontend/react/src/pages/Mfa.tsx
@@ -61,7 +61,7 @@ const Mfa: React.FC = () => {
         } else if (error.response.status === 403) {
         setError(t("mfa.otpExpired"));
         } else {
-        setError(t("mfa.tryAgainError"));
+        setError(t("mfa.invalidOtp"));
         }
       } else {
         setError(t("mfa.generalError"));

--- a/frontend/react/src/pages/PongPals.tsx
+++ b/frontend/react/src/pages/PongPals.tsx
@@ -1,14 +1,12 @@
-import React, { useState, useEffect } from "react";
-import axios from "axios";
-import { Navigate, useNavigate } from "react-router-dom";
-import SearchPals from "../components/SearchPals";
-import { FriendList } from "../components/FriendList";
-import { PendingRequests } from "../components/PendingRequests";
-import { useAuth } from "../auth/AuthProvider";
-import { Friend } from "../types/friend";
-import { useTranslation } from "react-i18next";
-
-const apiUrl = import.meta.env.VITE_API_BASE_URL || "api";
+import React, { useState, useEffect } from 'react';
+import api from '../api/axios';
+import { Navigate, useNavigate } from 'react-router-dom';
+import SearchPals from '../components/SearchPals';
+import { FriendList } from '../components/FriendList';
+import { PendingRequests } from '../components/PendingRequests';
+import { useAuth } from '../auth/AuthProvider';
+import { Friend } from '../types/friend';
+import { useTranslation } from 'react-i18next';
 
 const PongPals: React.FC = () => {
   const navigate = useNavigate();
@@ -18,23 +16,16 @@ const PongPals: React.FC = () => {
 
   useEffect(() => {
     if (user) {
-      const fetchFriends = async () => {
-        try {
-          const response = await axios.get(
-            apiUrl + `/users/${user.id}/friends`,
-            {
-              withCredentials: true,
-              headers: {
-                "Content-Type": "application/json", // optional but safe
-              },
-            }
-          );
-          setFriends(response.data);
-        } catch (error) {
-          console.error("Failed to fetch friends:", error);
-        }
-      };
-
+			const fetchFriends = async () => {
+				try {
+					const response = await api.get(`/users/${user.id}/friends`, {
+						headers: { "Content-Type": "application/json" },
+					});
+					setFriends(response.data);
+				} catch (error) {
+					console.error('Failed to fetch friends:', error);
+				}
+			};
       fetchFriends();
     }
   }, [user]);
@@ -49,9 +40,9 @@ const PongPals: React.FC = () => {
 
   const inputStyles =
     "bg-gray-50 border border-gray-300 text-gray-900 text-sm rounded-lg focus:ring-blue-500 focus:border-blue-500 block w-full p-2.5 dark:bg-gray-700 dark:border-gray-600 dark:placeholder-gray-400 dark:text-white dark:focus:ring-blue-500 dark:focus:border-blue-500";
-
-  if (status === "loading") return <p>Loading...</p>;
-  if (status === "unauthorized") return <Navigate to="/" replace />;
+	
+	if (status === 'loading') return <p>Loading...</p>
+	if (status === 'unauthorized') return <Navigate to="/login" replace />;
 
   // add friend request header to component
   return (

--- a/frontend/react/src/pages/PongPals.tsx
+++ b/frontend/react/src/pages/PongPals.tsx
@@ -1,12 +1,12 @@
-import React, { useState, useEffect } from 'react';
-import api from '../api/axios';
-import { Navigate, useNavigate } from 'react-router-dom';
-import SearchPals from '../components/SearchPals';
-import { FriendList } from '../components/FriendList';
-import { PendingRequests } from '../components/PendingRequests';
-import { useAuth } from '../auth/AuthProvider';
-import { Friend } from '../types/friend';
-import { useTranslation } from 'react-i18next';
+import React, { useState, useEffect } from "react";
+import api from "../api/axios";
+import { Navigate, useNavigate } from "react-router-dom";
+import SearchPals from "../components/SearchPals";
+import { FriendList } from "../components/FriendList";
+import { PendingRequests } from "../components/PendingRequests";
+import { useAuth } from "../auth/AuthProvider";
+import { Friend } from "../types/friend";
+import { useTranslation } from "react-i18next";
 
 const PongPals: React.FC = () => {
   const navigate = useNavigate();
@@ -16,16 +16,16 @@ const PongPals: React.FC = () => {
 
   useEffect(() => {
     if (user) {
-			const fetchFriends = async () => {
-				try {
-					const response = await api.get(`/users/${user.id}/friends`, {
-						headers: { "Content-Type": "application/json" },
-					});
-					setFriends(response.data);
-				} catch (error) {
-					console.error('Failed to fetch friends:', error);
-				}
-			};
+      const fetchFriends = async () => {
+        try {
+          const response = await api.get(`/users/${user.id}/friends`, {
+            headers: { "Content-Type": "application/json" },
+          });
+          setFriends(response.data);
+        } catch (error) {
+          console.error("Failed to fetch friends:", error);
+        }
+      };
       fetchFriends();
     }
   }, [user]);
@@ -40,9 +40,9 @@ const PongPals: React.FC = () => {
 
   const inputStyles =
     "bg-gray-50 border border-gray-300 text-gray-900 text-sm rounded-lg focus:ring-blue-500 focus:border-blue-500 block w-full p-2.5 dark:bg-gray-700 dark:border-gray-600 dark:placeholder-gray-400 dark:text-white dark:focus:ring-blue-500 dark:focus:border-blue-500";
-	
-	if (status === 'loading') return <p>Loading...</p>
-	if (status === 'unauthorized') return <Navigate to="/login" replace />;
+
+  if (status === "loading") return <p>Loading...</p>;
+  if (status === "unauthorized") return <Navigate to="/login" replace />;
 
   // add friend request header to component
   return (

--- a/frontend/react/src/pages/Settings.tsx
+++ b/frontend/react/src/pages/Settings.tsx
@@ -10,6 +10,8 @@ import api from '../api/axios';
 import ConfirmOtpField from '../components/ConfirmOtpField';
 import { useTranslation } from 'react-i18next';
 
+const apiUrl = import.meta.env.VITE_API_BASE_URL || 'api';
+
 const Settings: React.FC = () => {
   const navigate = useNavigate();
   const { status, user, refreshSession } = useAuth();
@@ -126,7 +128,7 @@ const Settings: React.FC = () => {
       const formData = new FormData();
       formData.append("file", file);
 
-      const res = await api.post("/user/profile-pic", formData);
+      await api.post("/user/profile-pic", formData);
 
       await refreshSession();
       console.log(user);
@@ -160,8 +162,8 @@ const Settings: React.FC = () => {
       <EditProfilePic
         pic={
           user?.profilePic
-            ? `${user.profilePic}`
-            : `/assets/default_avatar.png`
+            ? `${apiUrl}${user.profilePic}`
+            : `${apiUrl}/assets/default_avatar.png`
         }
         onChange={() => {}}
         onSave={uploadProfilePic}

--- a/frontend/react/src/pages/Settings.tsx
+++ b/frontend/react/src/pages/Settings.tsx
@@ -1,16 +1,16 @@
-import React, { useState, useEffect } from 'react';
-import { Navigate, useNavigate } from 'react-router-dom';
-import { useAuth } from '../auth/AuthProvider';
-import DeleteAccountButton from '../components/DeleteAccount';
-import EditProfilePic from '../components/EditProfilePic';
-import SettingsField from '../components/SettingsField';
-import LanguageSelector from '../components/LanguageSelector';
-import ToggleSwitch from '../components/ToggleSwitch';
-import api from '../api/axios';
-import ConfirmOtpField from '../components/ConfirmOtpField';
-import { useTranslation } from 'react-i18next';
+import React, { useState, useEffect } from "react";
+import { Navigate, useNavigate } from "react-router-dom";
+import { useAuth } from "../auth/AuthProvider";
+import DeleteAccountButton from "../components/DeleteAccount";
+import EditProfilePic from "../components/EditProfilePic";
+import SettingsField from "../components/SettingsField";
+import LanguageSelector from "../components/LanguageSelector";
+import ToggleSwitch from "../components/ToggleSwitch";
+import api from "../api/axios";
+import ConfirmOtpField from "../components/ConfirmOtpField";
+import { useTranslation } from "react-i18next";
 
-const apiUrl = import.meta.env.VITE_API_BASE_URL || 'api';
+const apiUrl = import.meta.env.VITE_API_BASE_URL || "api";
 
 const Settings: React.FC = () => {
   const navigate = useNavigate();
@@ -56,10 +56,7 @@ const Settings: React.FC = () => {
     if (!user?.id) throw new Error("No user ID available");
 
     try {
-      await api.post(
-        `/users/delete/${user?.id}`,
-        { password },
-      );
+      await api.post(`/users/delete/${user?.id}`, { password });
       localStorage.clear();
       sessionStorage.clear();
       await refreshSession();
@@ -79,20 +76,18 @@ const Settings: React.FC = () => {
     try {
       // send request to backend to update 2FA status
       if (is2FAEnabled === true) {
-        const response = await api.post(
-          "/auth/mfa",
-          { mfaInUse: !is2FAEnabled },
-        );
+        const response = await api.post("/auth/mfa", {
+          mfaInUse: !is2FAEnabled,
+        });
         setIs2FAEnabled(response.data.mfaInUse);
         console.log("2FA toggled!");
       } //check if email is already validated and show the Otp field to validate email if not
       else {
         const user = await api.get("/users/emailStatus", {});
         if (user.data.emailVerified === true) {
-          const response = await api.post(
-            "/auth/mfa",
-            { mfaInUse: !is2FAEnabled },
-          );
+          const response = await api.post("/auth/mfa", {
+            mfaInUse: !is2FAEnabled,
+          });
           setIs2FAEnabled(response.data.mfaInUse);
           console.log("2FA toggled!");
         } else {
@@ -107,8 +102,7 @@ const Settings: React.FC = () => {
                 `Please wait ${waitTime} seconds before requesting a new OTP.`
               );
             } else {
-              await api.post(
-                "/auth/otp/send-otp", {});
+              await api.post("/auth/otp/send-otp", {});
             }
           } catch (error) {
             console.error("Error sending OTP:", error);
@@ -140,10 +134,7 @@ const Settings: React.FC = () => {
 
   const handleLanguageChange = async (newLang: string) => {
     try {
-      const response = await api.post(
-        "/user/language",
-        { language: newLang },
-      );
+      const response = await api.post("/user/language", { language: newLang });
 
       setLanguage(response.data.language);
       i18n.changeLanguage(response.data.language);

--- a/frontend/react/src/pages/Stats.tsx
+++ b/frontend/react/src/pages/Stats.tsx
@@ -1,16 +1,14 @@
-import React, { useEffect, useState } from "react";
-import { Navigate, useLocation } from "react-router-dom";
-import { useAuth } from "../auth/AuthProvider";
-import axios from "axios";
-import { useTranslation } from "react-i18next";
+import React, { useEffect, useState } from 'react';
+import { Navigate, useLocation } from 'react-router-dom';
+import { useAuth } from '../auth/AuthProvider';
+import api from '../api/axios';
+import { useTranslation } from 'react-i18next';
 
 import StatsHeader from "../components/StatsHeader";
 import MatchHistory from "../components/MatchHistory";
 import BefriendButton from "../components/BefriendButton";
 
-const apiUrl = import.meta.env.VITE_API_BASE_URL || "/api";
-
-const Stats: React.FC = () => {
+const Stats: React.FC= () => {
   const { status, user } = useAuth();
   const { state } = useLocation();
   const [viewedUserUsername, setViewedUserUsername] = useState<string | null>(
@@ -26,12 +24,9 @@ const Stats: React.FC = () => {
       if (!viewedUserId || usernameFromState) return;
 
       try {
-        const res = await axios.get(apiUrl + "/users/id", {
+        const res = await api.get('/users/id', {
           params: { id: viewedUserId },
-          headers: {
-            "Content-Type": "application/json",
-          },
-          withCredentials: true,
+          headers: { "Content-Type": "application/json" },
         });
         setViewedUserUsername(res.data.username);
       } catch (error) {
@@ -43,8 +38,8 @@ const Stats: React.FC = () => {
     if (status === "authorized") fetchUsername();
   }, [status, viewedUserId, usernameFromState, t]);
 
-  if (status === "loading") return <p>{t("stats.loading")}</p>;
-  if (status === "unauthorized" || !user) return <Navigate to="/" replace />;
+  if (status === 'loading') return <p>{t('stats.loading')}</p>;
+  if (status === 'unauthorized' || !user) return <Navigate to="/login" replace/>;
 
   return (
     <div className="text-center max-w-2xl dark:bg-black bg-white mx-auto rounded-lg">

--- a/frontend/react/src/pages/Stats.tsx
+++ b/frontend/react/src/pages/Stats.tsx
@@ -1,14 +1,14 @@
-import React, { useEffect, useState } from 'react';
-import { Navigate, useLocation } from 'react-router-dom';
-import { useAuth } from '../auth/AuthProvider';
-import api from '../api/axios';
-import { useTranslation } from 'react-i18next';
+import React, { useEffect, useState } from "react";
+import { Navigate, useLocation } from "react-router-dom";
+import { useAuth } from "../auth/AuthProvider";
+import api from "../api/axios";
+import { useTranslation } from "react-i18next";
 
 import StatsHeader from "../components/StatsHeader";
 import MatchHistory from "../components/MatchHistory";
 import BefriendButton from "../components/BefriendButton";
 
-const Stats: React.FC= () => {
+const Stats: React.FC = () => {
   const { status, user } = useAuth();
   const { state } = useLocation();
   const [viewedUserUsername, setViewedUserUsername] = useState<string | null>(
@@ -24,7 +24,7 @@ const Stats: React.FC= () => {
       if (!viewedUserId || usernameFromState) return;
 
       try {
-        const res = await api.get('/users/id', {
+        const res = await api.get("/users/id", {
           params: { id: viewedUserId },
           headers: { "Content-Type": "application/json" },
         });
@@ -38,8 +38,9 @@ const Stats: React.FC= () => {
     if (status === "authorized") fetchUsername();
   }, [status, viewedUserId, usernameFromState, t]);
 
-  if (status === 'loading') return <p>{t('stats.loading')}</p>;
-  if (status === 'unauthorized' || !user) return <Navigate to="/login" replace/>;
+  if (status === "loading") return <p>{t("stats.loading")}</p>;
+  if (status === "unauthorized" || !user)
+    return <Navigate to="/login" replace />;
 
   return (
     <div className="text-center max-w-2xl dark:bg-black bg-white mx-auto rounded-lg">

--- a/frontend/react/src/types/friend.ts
+++ b/frontend/react/src/types/friend.ts
@@ -1,5 +1,5 @@
 export type Friend = {
-	id: string;
-	username: string;
-	isOnline: boolean;
+  id: string;
+  username: string;
+  isOnline: boolean;
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -157,9 +157,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",


### PR DESCRIPTION
This pull request introduces enhanced token expiry handling logic. Middleware used to check the validity of the token on backend side now responds with 419. 401 and 419 are handled in the frontend via global axios interceptor that tracks failed backend calls and responds accordingly. AuthProvider performs a session validity check on logged in users every 10 minutes, alerts the user upon session expiry and redirects to login page. apiUrl is now universally available through `axios.ts` with cookies enabled which simplifies all backend calls in frontend. Example usage:

```
import api from "../api/axios”;
…
variable = await api.get(“/extension-without-apiurl", {arguments if applicable});
```

* Added session expiration handling in `authenticate` middleware to return a `419 Session expired` response if the token has expired.
* Enhanced `authenticateOptional` middleware to handle expired tokens by setting `request.user` to `undefined` and returning a `419 Session expired` response. 
* Replaced direct `axios` imports with a centralized `api` instance in `frontend/react/src/api/axios.ts` for consistent configuration.
* Introduced `setupInterceptors` in `frontend/react/src/api/setupInterceptors.ts` to handle session expiration globally by intercepting API responses.
* Updated `AuthProvider` in `frontend/react/src/auth/AuthProvider.tsx` to handle session expiration alerts, redirect users to the login page, and set up interceptors after the initial session validity check. 
* Refactored `frontend/react/src/App.tsx` to remove `BrowserRouter` import and use the centralized `api` instance for logout functionality. 

HOW TO TEST:
- jwts will be valid for 1h, but it’s easier to test if their expiry time is changed from `1h` to `5m` (5 minutes) for strings and `5 * 60` for numbers
- apply changes on the following files/lines for testing:
——> `backend/srcs/middleware/authenticate.js:33,42`
——> `backend/srcs/middleware/authenticateOptional.js:25` (change the if condition to: 'if (2 * 60)’ so that it can check validity when half of the time is left)
——> `backend/srcs/middleware/authenticateOptional.js:29,37`
——> `backend/srcs/routes/users.js:85,99`
——> `frontend/react/src/auth/AuthProvider.tsx:87` (take zero out of 10 for example so that the check is performed once a minute)

UPON JWT EXPIRY (ie expected behavior):
- page should stop rendering restricted content leaving only the background image visible to the user (due to rendered content === null), and
- pops an alert notifying user about their session expiry and requesting they log in again
- redirects user to login page
