### PR TITLE
Improve data collection in TournamentBuilder

### DIFF
--- a/frontend/react/src/App.tsx
+++ b/frontend/react/src/App.tsx
@@ -8,6 +8,7 @@ import Settings from "./pages/Settings";
 import ForgotPassword from "./pages/ForgotPassword";
 import Stats from "./pages/Stats";
 import VerifyEmail from "./pages/VerifyEmail";
+import TournamentPage from "./pages/TournamentPage";
 import showDatabase from "./components/showDatabase";
 import NavigationHeader from "./components/NavigationHeader";
 import { useAuth } from "./auth/AuthProvider";
@@ -46,6 +47,7 @@ const App: React.FC = () => {
         <Route path="/settings" element={<Settings />} />
         <Route path="/stats" element={<Stats />} />
         <Route path="/mfa" element={<Mfa />} />
+        <Route path="/tournament/:id" element={<TournamentPage />} />
         <Route path="*" element={<Navigate to="/" replace />} />
         <Route
           path="/stats/:anything"

--- a/frontend/react/src/components/TournamentBuilder.tsx
+++ b/frontend/react/src/components/TournamentBuilder.tsx
@@ -1,35 +1,133 @@
 import React, { useEffect, useState } from "react";
+import { useAuth } from "../auth/AuthProvider";
+import { useNavigate } from "react-router-dom";
+import PlayerRegistrationBox from "./PlayerRegistrationBox";
+import api from "../api/axios";
+
+type RegisteredPlayer = {
+  username: string;
+  isGuest: boolean;
+};
 
 const TournamentBuilder = () => {
   const [playerCount, setPlayerCount] = useState<number>(0);
+  const [players, setPlayers] = useState<RegisteredPlayer[]>([]);
+  const [registeredPlayers, setRegisteredPlayers] = useState<boolean[]>([]);
+  const { user } = useAuth();
+  const navigate = useNavigate();
+  const usernameRegex = /^[a-zA-Z0-9]+$/;
+
   useEffect(() => {
-    {
-      console.log("playerCount: ", playerCount);
+    if (playerCount > 0) {
+      const initialPlayers: RegisteredPlayer[] = Array(playerCount).fill({
+        username: "",
+        isGuest: true,
+      });
+
+      if (user) {
+        initialPlayers[0] = {
+          username: user.username,
+          isGuest: false,
+        };
+      }
+
+      setPlayers(initialPlayers);
+      // initialize registeredPlayers: first player is registered if logged in, otherwise false
+      setRegisteredPlayers(
+        initialPlayers.map((_, idx) => (user && idx === 0 ? true : false))
+      );
     }
-  }, [playerCount]);
+  }, [playerCount, user]);
+
+  const updatePlayer = (index: number, player: RegisteredPlayer) => {
+    // check for duplicate usernames
+    const duplicate = players.some(
+      (p, i) => i !== index && p.username === player.username
+    );
+    if (duplicate) {
+      alert(`Username "${player.username}" is already taken.`);
+      return;
+    }
+    // prevent re-login of logged-in user
+    if (user && index !== 0 && player.username === user.username) {
+      alert(`You're already logged in as ${user.username}.`);
+      return;
+    }
+    // enforce username rules
+    if (
+      !usernameRegex.test(player.username) ||
+      player.username.length < 2 ||
+      player.username.length > 20
+    ) {
+      alert("Username must be alphanumeris and between 2 and 20 characters.");
+      return;
+    }
+    const updatedPlayers = [...players];
+    updatedPlayers[index] = player;
+    setPlayers(updatedPlayers);
+
+    // mark this player as registered (hides input fields from them)
+    const updatedRegistered = [...registeredPlayers];
+    updatedRegistered[index] = true;
+    setRegisteredPlayers(updatedRegistered);
+  };
+
+  const handleCreateTournament = async (e: React.FormEvent) => {
+    console.log(`Let's make a tournament`);
+    e.preventDefault();
+
+    // ensure logged in user is counted in all checks
+    if (user) {
+      players[0] = {
+        username: user.username,
+        isGuest: false,
+      };
+    }
+
+    // basic validation
+    if (
+      players.some((p, i) => {
+        if (user && i === 0) return false; // skip first player if user is logged in
+        return !p.username;
+      })
+    ) {
+      alert("All players must enter a username.");
+      return;
+    }
+
+    try {
+      // create a tournament
+      /*const res = await api.post("/tournaments", {
+        name: "Pong Tournament",
+        size: playerCount,
+        createdById: user?.id,
+        status: "waiting",
+      });*/
+
+      //const tournamentId = res.data.id;
+      const tournamentId = 0;
+
+      // add participants
+      /*await Promise.all(
+        players.map((player, index) =>
+          api.post("/tournament-participants", {
+            tournamentId,
+            userId: player.isGuest ? null : (user?.username === player.username ? user.id : null),
+            alias: player.isGuest ? player.username : "",
+          })
+        )
+      );*/
+      navigate(`/tournament/${tournamentId}`);
+    } catch (error) {
+      console.error("Tournament creation failed.");
+      alert("Error creating tournament.");
+    }
+  };
+
   const inputStyles =
     "bg-gray-50 border border-gray-300 text-gray-900 text-sm rounded-lg focus:ring-blue-500 focus:border-blue-500 block p-2.5 m-1 w-xs dark:bg-gray-700 dark:border-gray-600 dark:placeholder-gray-400 dark:text-white dark:focus:ring-blue-500 dark:focus:border-blue-500";
   const buttonStyles =
     "px-5 mx-3 py-5 my-2 text-white bg-teal-700 hover:bg-teal-800 focus:ring-4 focus:outline-none focus:ring-blue-300 font-semibold rounded-lg text-sm w-full sm:w-auto py-2.5 text-center dark:bg-teal-600 dark:hover:bg-teal-700 dark:focus:ring-teal-800";
-
-  type PlayerInputProps = { playerNumber: number };
-  const PlayerInput = ({ playerNumber }: PlayerInputProps) => {
-    return (
-      <div className="p-5 text-center max-w-2xl dark:bg-black bg-white mx-auto rounded-lg dark:text-white">
-        <label htmlFor={playerNumber.toString()}>
-          Player {playerNumber.toString()}:{" "}
-        </label>
-        <input id={playerNumber.toString()} className={inputStyles} />
-      </div>
-    );
-  };
-  const handlePlayers = (players: number) => {
-    // <input className={inputStyles}></input>;
-    setPlayerCount(players);
-  };
-  const handleCreateTournament = () => {
-    console.log(`Let's make a tournament`);
-  };
 
   if (playerCount === 0)
     return (
@@ -38,10 +136,10 @@ const TournamentBuilder = () => {
           Create Tournament
         </h1>
         <div className="flex flex-col">
-          <button className={buttonStyles} onClick={() => handlePlayers(4)}>
+          <button className={buttonStyles} onClick={() => setPlayerCount(4)}>
             4 player mode
           </button>
-          <button className={buttonStyles} onClick={() => handlePlayers(8)}>
+          <button className={buttonStyles} onClick={() => setPlayerCount(8)}>
             8 player mode
           </button>
         </div>
@@ -54,16 +152,31 @@ const TournamentBuilder = () => {
           Create Tournament
         </h1>
         <p className="dark:text-white">
-          Enter the usernames of all tournament participants.
+          Enter the usernames or register as a guest.
         </p>
-        <form className="flex flex-col">
-          {Array.from({ length: playerCount }, (element, index) => (
-            <PlayerInput playerNumber={index + 1} key={index} />
+        <div className="flex flex-col">
+          {players.map((player, index) => (
+            <div key={index} className="my-2">
+              {user && index === 0 ? (
+                <div className="text-center text-teal-800 dark:text-teal-300 font-bold">
+                  Player 1 (You): {user.username}
+                </div>
+              ) : registeredPlayers[index] ? (
+                <div className="text-center text-teal-800 dark:text-teal-300 font-semibold">
+                  Player {index + 1}: {player.username}
+                </div>
+              ) : (
+                <PlayerRegistrationBox
+                  label={`Player ${index + 1}`}
+                  onRegister={(p) => updatePlayer(index, p)}
+                />
+              )}
+            </div>
           ))}
-          <button className={buttonStyles} type="submit">
+          <button className={buttonStyles} onClick={handleCreateTournament}>
             Create Tournament
           </button>
-        </form>
+        </div>
       </div>
     );
 };

--- a/frontend/react/src/pages/TournamentPage.tsx
+++ b/frontend/react/src/pages/TournamentPage.tsx
@@ -1,0 +1,36 @@
+import React from "react";
+import { useParams, useNavigate } from "react-router-dom";
+
+const TournamentPage = () => {
+  const { id } = useParams();
+  const navigate = useNavigate();
+
+  return (
+    <div className="flex flex-col items-center justify-center min-h-screen bg-gray-100 dark:bg-gray-900 text-gray-900 dark:text-white px-4">
+      <h1 className="text-5xl font-bold text-teal-700 dark:text-teal-300 mb-6">
+        Tournament #{id}
+      </h1>
+
+      <p className="mb-4 text-center max-w-lg">
+        This is a placeholder for the tournament bracket and match making logic.
+      </p>
+
+      <div className="flex gap-4">
+        <button
+          className="px-6 py-2 rounded-lg bg-teal-600 hover:bg-teal-700 text-white font-semibold"
+          onClick={() => alert("Bracket not implemented yet!")}
+        >
+          View Bracket
+        </button>
+        <button
+          className="px-6 py-2 rounded-lg bg-gray-300 hover:bg-gray-400 text-gray-900 font-semibold"
+          onClick={() => navigate("/")}
+        >
+          Back to Home
+        </button>
+      </div>
+    </div>
+  );
+};
+
+export default TournamentPage;


### PR DESCRIPTION
This is a small improvement introducing PlayerRegistrationBox implemented as part of the TournamentBuilder logic to collect player data for tournaments. Forces registering players to follow username guidelines. Allows the first player to login (hence fixes the issue for 2 player game version login issue) and uses their JWT to validate the session. Hides input fields from user after clicking ‘Continue’. Redirects to a moc bracket page.

Things not covered:
- prompt for OTP if user has 2FA enabled
- hide tournament ID from url
- misses implementation for saving tournament data in the backend
- PlayerRegistrationBox needs an alternate API route for player login without cookie generation