### PR TITLE
added OTP verification route without using cookies

### DIFF
--- a/backend/srcs/APItest/testAPI.http
+++ b/backend/srcs/APItest/testAPI.http
@@ -95,6 +95,14 @@ content-type: application/json
 
 ###
 
+POST http://localhost:3000/auth/verify-tournamentOtp HTTP/1.1
+content-type: application/json
+
+{
+    "code": "162811",
+    "email": "casi.lehtovuori@gmail.com"
+}
+###
 
 
 


### PR DESCRIPTION
This pull request introduces a new API endpoint for verifying tournament OTPs and integrates rate-limiting to enhance security and prevent abuse. The changes span multiple files, including the addition of the endpoint logic, rate-limiting configuration, and a test case for the new endpoint.

### New API Endpoint for Tournament OTP Verification:

* [`backend/srcs/routes/otp.js`](diffhunk://#diff-305623f9188a79f854093338a6431cc257fed3fd4ed6e82fc341820bf078f9afR152-R202): Added a new route `/auth/verify-tournamentOtp` to verify OTPs without creating a cookie. The route validates the OTP against the database, checks for expiration, deletes the OTP upon successful verification, and handles error scenarios such as invalid OTPs or expired codes.

### Rate-Limiting Integration:

* [`backend/srcs/routes/otp.js`](diffhunk://#diff-305623f9188a79f854093338a6431cc257fed3fd4ed6e82fc341820bf078f9afR3-R15): Integrated the `@fastify/rate-limit` plugin and configured rate-limiting for the new OTP verification route to allow a maximum of 10 requests per minute per IP address. [[1]](diffhunk://#diff-305623f9188a79f854093338a6431cc257fed3fd4ed6e82fc341820bf078f9afR3-R15) [[2]](diffhunk://#diff-305623f9188a79f854093338a6431cc257fed3fd4ed6e82fc341820bf078f9afR152-R202)

### Test Case for Tournament OTP Verification:

* [`backend/srcs/APItest/testAPI.http`](diffhunk://#diff-e3c860711f48bc0707bb8348330d3668478962ba417172f36cd59f7e5e5351eeR98-R105): Added a test case for the new `/auth/verify-tournamentOtp` endpoint, including sample payload data for verifying an OTP.