### PR TITLE
Api schemas

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -54,11 +54,11 @@ down:
 fclean: down
 	@printf "Clean of all docker configs\n"
 	@docker rmi backend frontend --force || true
-	@rm -rf ./frontend/srcs/react/dist
+	@rm -rf ./frontend/react/dist
 
 deepclean: fclean
 	@printf "Deepcleaning all docker configs and node_modules\n"
-	@rm -rf ./frontend/node_modules
+	@rm -rf ./frontend/react/node_modules
 	@rm -rf ./backend/node_modules
 
 re: fclean all

--- a/Makefile
+++ b/Makefile
@@ -53,8 +53,13 @@ down:
 
 fclean: down
 	@printf "Clean of all docker configs\n"
-	@docker system prune --all
+	@docker rmi backend frontend --force || true
 	@rm -rf ./frontend/srcs/react/dist
+
+deepclean: fclean
+	@printf "Deepcleaning all docker configs and node_modules\n"
+	@rm -rf ./frontend/node_modules
+	@rm -rf ./backend/node_modules
 
 re: fclean all
 

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -16,7 +16,7 @@
         "@fastify/multipart": "^9.0.3",
         "@fastify/rate-limit": "^10.3.0",
         "@fastify/static": "^8.2.0",
-        "@prisma/client": "^6.11.1",
+        "@prisma/client": "^6.12.0",
         "bcryptjs": "^2.4.3",
         "dotenv": "^16.5.0",
         "fastify": "^5.2.2",
@@ -31,7 +31,7 @@
         "eslint-plugin-react": "^7.37.5",
         "globals": "^16.2.0",
         "nodemon": "^3.1.9",
-        "prisma": "^6.11.1"
+        "prisma": "^6.12.0"
       }
     },
     "node_modules/@emnapi/runtime": {
@@ -1162,9 +1162,9 @@
       }
     },
     "node_modules/@prisma/client": {
-      "version": "6.11.1",
-      "resolved": "https://registry.npmjs.org/@prisma/client/-/client-6.11.1.tgz",
-      "integrity": "sha512-5CLFh8QP6KxRm83pJ84jaVCeSVPQr8k0L2SEtOJHwdkS57/VQDcI/wQpGmdyOZi+D9gdNabdo8tj1Uk+w+upsQ==",
+      "version": "6.12.0",
+      "resolved": "https://registry.npmjs.org/@prisma/client/-/client-6.12.0.tgz",
+      "integrity": "sha512-wn98bJ3Cj6edlF4jjpgXwbnQIo/fQLqqQHPk2POrZPxTlhY3+n90SSIF3LMRVa8VzRFC/Gec3YKJRxRu+AIGVA==",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "engines": {
@@ -1184,9 +1184,9 @@
       }
     },
     "node_modules/@prisma/config": {
-      "version": "6.11.1",
-      "resolved": "https://registry.npmjs.org/@prisma/config/-/config-6.11.1.tgz",
-      "integrity": "sha512-z6rCTQN741wxDq82cpdzx2uVykpnQIXalLhrWQSR0jlBVOxCIkz3HZnd8ern3uYTcWKfB3IpVAF7K2FU8t/8AQ==",
+      "version": "6.12.0",
+      "resolved": "https://registry.npmjs.org/@prisma/config/-/config-6.12.0.tgz",
+      "integrity": "sha512-HovZWzhWEMedHxmjefQBRZa40P81N7/+74khKFz9e1AFjakcIQdXgMWKgt20HaACzY+d1LRBC+L4tiz71t9fkg==",
       "devOptional": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -1194,53 +1194,53 @@
       }
     },
     "node_modules/@prisma/debug": {
-      "version": "6.11.1",
-      "resolved": "https://registry.npmjs.org/@prisma/debug/-/debug-6.11.1.tgz",
-      "integrity": "sha512-lWRb/YSWu8l4Yum1UXfGLtqFzZkVS2ygkWYpgkbgMHn9XJlMITIgeMvJyX5GepChzhmxuSuiq/MY/kGFweOpGw==",
+      "version": "6.12.0",
+      "resolved": "https://registry.npmjs.org/@prisma/debug/-/debug-6.12.0.tgz",
+      "integrity": "sha512-plbz6z72orcqr0eeio7zgUrZj5EudZUpAeWkFTA/DDdXEj28YHDXuiakvR6S7sD6tZi+jiwQEJAPeV6J6m/tEQ==",
       "devOptional": true,
       "license": "Apache-2.0"
     },
     "node_modules/@prisma/engines": {
-      "version": "6.11.1",
-      "resolved": "https://registry.npmjs.org/@prisma/engines/-/engines-6.11.1.tgz",
-      "integrity": "sha512-6eKEcV6V8W2eZAUwX2xTktxqPM4vnx3sxz3SDtpZwjHKpC6lhOtc4vtAtFUuf5+eEqBk+dbJ9Dcaj6uQU+FNNg==",
+      "version": "6.12.0",
+      "resolved": "https://registry.npmjs.org/@prisma/engines/-/engines-6.12.0.tgz",
+      "integrity": "sha512-4BRZZUaAuB4p0XhTauxelvFs7IllhPmNLvmla0bO1nkECs8n/o1pUvAVbQ/VOrZR5DnF4HED0PrGai+rIOVePA==",
       "devOptional": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@prisma/debug": "6.11.1",
-        "@prisma/engines-version": "6.11.1-1.f40f79ec31188888a2e33acda0ecc8fd10a853a9",
-        "@prisma/fetch-engine": "6.11.1",
-        "@prisma/get-platform": "6.11.1"
+        "@prisma/debug": "6.12.0",
+        "@prisma/engines-version": "6.12.0-15.8047c96bbd92db98a2abc7c9323ce77c02c89dbc",
+        "@prisma/fetch-engine": "6.12.0",
+        "@prisma/get-platform": "6.12.0"
       }
     },
     "node_modules/@prisma/engines-version": {
-      "version": "6.11.1-1.f40f79ec31188888a2e33acda0ecc8fd10a853a9",
-      "resolved": "https://registry.npmjs.org/@prisma/engines-version/-/engines-version-6.11.1-1.f40f79ec31188888a2e33acda0ecc8fd10a853a9.tgz",
-      "integrity": "sha512-swFJTOOg4tHyOM1zB/pHb3MeH0i6t7jFKn5l+ZsB23d9AQACuIRo9MouvuKGvnDogzkcjbWnXi/NvOZ0+n5Jfw==",
+      "version": "6.12.0-15.8047c96bbd92db98a2abc7c9323ce77c02c89dbc",
+      "resolved": "https://registry.npmjs.org/@prisma/engines-version/-/engines-version-6.12.0-15.8047c96bbd92db98a2abc7c9323ce77c02c89dbc.tgz",
+      "integrity": "sha512-70vhecxBJlRr06VfahDzk9ow4k1HIaSfVUT3X0/kZoHCMl9zbabut4gEXAyzJZxaCGi5igAA7SyyfBI//mmkbQ==",
       "devOptional": true,
       "license": "Apache-2.0"
     },
     "node_modules/@prisma/fetch-engine": {
-      "version": "6.11.1",
-      "resolved": "https://registry.npmjs.org/@prisma/fetch-engine/-/fetch-engine-6.11.1.tgz",
-      "integrity": "sha512-NBYzmkXTkj9+LxNPRSndaAeALOL1Gr3tjvgRYNqruIPlZ6/ixLeuE/5boYOewant58tnaYFZ5Ne0jFBPfGXHpQ==",
+      "version": "6.12.0",
+      "resolved": "https://registry.npmjs.org/@prisma/fetch-engine/-/fetch-engine-6.12.0.tgz",
+      "integrity": "sha512-EamoiwrK46rpWaEbLX9aqKDPOd8IyLnZAkiYXFNuq0YsU0Z8K09/rH8S7feOWAVJ3xzeSgcEJtBlVDrajM9Sag==",
       "devOptional": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@prisma/debug": "6.11.1",
-        "@prisma/engines-version": "6.11.1-1.f40f79ec31188888a2e33acda0ecc8fd10a853a9",
-        "@prisma/get-platform": "6.11.1"
+        "@prisma/debug": "6.12.0",
+        "@prisma/engines-version": "6.12.0-15.8047c96bbd92db98a2abc7c9323ce77c02c89dbc",
+        "@prisma/get-platform": "6.12.0"
       }
     },
     "node_modules/@prisma/get-platform": {
-      "version": "6.11.1",
-      "resolved": "https://registry.npmjs.org/@prisma/get-platform/-/get-platform-6.11.1.tgz",
-      "integrity": "sha512-b2Z8oV2gwvdCkFemBTFd0x4lsL4O2jLSx8lB7D+XqoFALOQZPa7eAPE1NU0Mj1V8gPHRxIsHnyUNtw2i92psUw==",
+      "version": "6.12.0",
+      "resolved": "https://registry.npmjs.org/@prisma/get-platform/-/get-platform-6.12.0.tgz",
+      "integrity": "sha512-nRerTGhTlgyvcBlyWgt8OLNIV7QgJS2XYXMJD1hysorMCuLAjuDDuoxmVt7C2nLxbuxbWPp7OuFRHC23HqD9dA==",
       "devOptional": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@prisma/debug": "6.11.1"
+        "@prisma/debug": "6.12.0"
       }
     },
     "node_modules/@tokenizer/inflate": {
@@ -5157,15 +5157,15 @@
       }
     },
     "node_modules/prisma": {
-      "version": "6.11.1",
-      "resolved": "https://registry.npmjs.org/prisma/-/prisma-6.11.1.tgz",
-      "integrity": "sha512-VzJToRlV0s9Vu2bfqHiRJw73hZNCG/AyJeX+kopbu4GATTjTUdEWUteO3p4BLYoHpMS4o8pD3v6tF44BHNZI1w==",
+      "version": "6.12.0",
+      "resolved": "https://registry.npmjs.org/prisma/-/prisma-6.12.0.tgz",
+      "integrity": "sha512-pmV7NEqQej9WjizN6RSNIwf7Y+jeh9mY1JEX2WjGxJi4YZWexClhde1yz/FuvAM+cTwzchcMytu2m4I6wPkIzg==",
       "devOptional": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@prisma/config": "6.11.1",
-        "@prisma/engines": "6.11.1"
+        "@prisma/config": "6.12.0",
+        "@prisma/engines": "6.12.0"
       },
       "bin": {
         "prisma": "build/index.js"

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -26,11 +26,14 @@
         "sqlite3": "^5.1.7"
       },
       "devDependencies": {
-        "@eslint/js": "^9.0.0",
-        "eslint": "^9.28.0",
+        "@eslint/js": "^9.31.0",
+        "eslint": "^9.31.0",
+        "eslint-config-prettier": "^10.1.5",
+        "eslint-plugin-prettier": "^5.5.1",
         "eslint-plugin-react": "^7.37.5",
         "globals": "^16.2.0",
         "nodemon": "^3.1.9",
+        "prettier": "^3.6.2",
         "prisma": "^6.12.0"
       }
     },
@@ -74,9 +77,9 @@
       }
     },
     "node_modules/@eslint/config-array": {
-      "version": "0.20.1",
-      "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.20.1.tgz",
-      "integrity": "sha512-OL0RJzC/CBzli0DrrR31qzj6d6i6Mm3HByuhflhl4LOBiWxN+3i6/t/ZQQNii4tjksXi8r2CRW1wMpWA2ULUEw==",
+      "version": "0.21.0",
+      "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.21.0.tgz",
+      "integrity": "sha512-ENIdc4iLu0d93HeYirvKmrzshzofPw6VkZRKQGe9Nv46ZnWUzcF1xV01dcvEg/1wXUR61OmmlSfyeyO7EvjLxQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -89,9 +92,9 @@
       }
     },
     "node_modules/@eslint/config-helpers": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.2.3.tgz",
-      "integrity": "sha512-u180qk2Um1le4yf0ruXH3PYFeEZeYC3p/4wCTKrr2U1CmGdzGi3KtY0nuPDH48UJxlKCC5RDzbcbh4X0XlqgHg==",
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.3.0.tgz",
+      "integrity": "sha512-ViuymvFmcJi04qdZeDc2whTHryouGcDlaxPqarTD0ZE10ISpxGUVZGZDx4w01upyIynL3iu6IXH2bS1NhclQMw==",
       "dev": true,
       "license": "Apache-2.0",
       "engines": {
@@ -99,9 +102,9 @@
       }
     },
     "node_modules/@eslint/core": {
-      "version": "0.14.0",
-      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.14.0.tgz",
-      "integrity": "sha512-qIbV0/JZr7iSDjqAc60IqbLdsj9GDt16xQtWD+B78d/HAlvysGdZZ6rpJHGAc2T0FQx1X6thsSPdnoiGKdNtdg==",
+      "version": "0.15.1",
+      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.15.1.tgz",
+      "integrity": "sha512-bkOp+iumZCCbt1K1CmWf0R9pM5yKpDv+ZXtvSyQpudrI9kuFLp+bM2WOPXImuD/ceQuaa8f5pj93Y7zyECIGNA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -186,9 +189,9 @@
       }
     },
     "node_modules/@eslint/js": {
-      "version": "9.28.0",
-      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.28.0.tgz",
-      "integrity": "sha512-fnqSjGWd/CoIp4EXIxWVK/sHA6DOHN4+8Ix2cX5ycOY7LG0UY8nHCU5pIp2eaE1Mc7Qd8kHspYNzYXT2ojPLzg==",
+      "version": "9.31.0",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.31.0.tgz",
+      "integrity": "sha512-LOm5OVt7D4qiKCqoiPbA7LWmI+tbw1VbTUowBcUMgQSuM6poJufkFkYDcQpo5KfgD39TnNySV26QjOh7VFpSyw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -217,19 +220,6 @@
       "dependencies": {
         "@eslint/core": "^0.15.0",
         "levn": "^0.4.1"
-      },
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      }
-    },
-    "node_modules/@eslint/plugin-kit/node_modules/@eslint/core": {
-      "version": "0.15.0",
-      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.15.0.tgz",
-      "integrity": "sha512-b7ePw78tEWWkpgZCDYkbqDOP8dmM6qe+AOC6iuJqlq1R/0ahMAeH3qynpnqKFGkMltrp44ohV4ubGyvLX28tzw==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@types/json-schema": "^7.0.15"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -1159,6 +1149,19 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/@pkgr/core": {
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/@pkgr/core/-/core-0.2.7.tgz",
+      "integrity": "sha512-YLT9Zo3oNPJoBjBc4q8G2mjU4tqIbf5CEOORbUUr48dCD9q3umJ3IPlVqOqDakPfd2HuwccBaqlGhN4Gmr5OWg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.20.0 || ^14.18.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/pkgr"
       }
     },
     "node_modules/@prisma/client": {
@@ -2534,19 +2537,19 @@
       }
     },
     "node_modules/eslint": {
-      "version": "9.28.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.28.0.tgz",
-      "integrity": "sha512-ocgh41VhRlf9+fVpe7QKzwLj9c92fDiqOj8Y3Sd4/ZmVA4Btx4PlUYPq4pp9JDyupkf1upbEXecxL2mwNV7jPQ==",
+      "version": "9.31.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.31.0.tgz",
+      "integrity": "sha512-QldCVh/ztyKJJZLr4jXNUByx3gR+TDYZCRXEktiZoUR3PGy4qCmSbkxcIle8GEwGpb5JBZazlaJ/CxLidXdEbQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.12.1",
-        "@eslint/config-array": "^0.20.0",
-        "@eslint/config-helpers": "^0.2.1",
-        "@eslint/core": "^0.14.0",
+        "@eslint/config-array": "^0.21.0",
+        "@eslint/config-helpers": "^0.3.0",
+        "@eslint/core": "^0.15.0",
         "@eslint/eslintrc": "^3.3.1",
-        "@eslint/js": "9.28.0",
+        "@eslint/js": "9.31.0",
         "@eslint/plugin-kit": "^0.3.1",
         "@humanfs/node": "^0.16.6",
         "@humanwhocodes/module-importer": "^1.0.1",
@@ -2558,9 +2561,9 @@
         "cross-spawn": "^7.0.6",
         "debug": "^4.3.2",
         "escape-string-regexp": "^4.0.0",
-        "eslint-scope": "^8.3.0",
-        "eslint-visitor-keys": "^4.2.0",
-        "espree": "^10.3.0",
+        "eslint-scope": "^8.4.0",
+        "eslint-visitor-keys": "^4.2.1",
+        "espree": "^10.4.0",
         "esquery": "^1.5.0",
         "esutils": "^2.0.2",
         "fast-deep-equal": "^3.1.3",
@@ -2590,6 +2593,53 @@
       },
       "peerDependenciesMeta": {
         "jiti": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/eslint-config-prettier": {
+      "version": "10.1.5",
+      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-10.1.5.tgz",
+      "integrity": "sha512-zc1UmCpNltmVY34vuLRV61r1K27sWuX39E+uyUnY8xS2Bex88VV9cugG+UZbRSRGtGyFboj+D8JODyme1plMpw==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "eslint-config-prettier": "bin/cli.js"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint-config-prettier"
+      },
+      "peerDependencies": {
+        "eslint": ">=7.0.0"
+      }
+    },
+    "node_modules/eslint-plugin-prettier": {
+      "version": "5.5.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-5.5.1.tgz",
+      "integrity": "sha512-dobTkHT6XaEVOo8IO90Q4DOSxnm3Y151QxPJlM/vKC0bVy+d6cVWQZLlFiuZPP0wS6vZwSKeJgKkcS+KfMBlRw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "prettier-linter-helpers": "^1.0.0",
+        "synckit": "^0.11.7"
+      },
+      "engines": {
+        "node": "^14.18.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint-plugin-prettier"
+      },
+      "peerDependencies": {
+        "@types/eslint": ">=8.0.0",
+        "eslint": ">=8.0.0",
+        "eslint-config-prettier": ">= 7.0.0 <10.0.0 || >=10.1.0",
+        "prettier": ">=3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/eslint": {
+          "optional": true
+        },
+        "eslint-config-prettier": {
           "optional": true
         }
       }
@@ -2814,6 +2864,13 @@
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
       "license": "MIT"
+    },
+    "node_modules/fast-diff": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/fast-diff/-/fast-diff-1.3.0.tgz",
+      "integrity": "sha512-VxPP4NqbUjj6MaAOafWeUn2cXWLcCtljklUtZf0Ind4XQ+QPtmA0b18zZy0jIQx+ExRVCR/ZQpBmik5lXshNsw==",
+      "dev": true,
+      "license": "Apache-2.0"
     },
     "node_modules/fast-json-stable-stringify": {
       "version": "2.1.0",
@@ -5156,6 +5213,35 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/prettier": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.6.2.tgz",
+      "integrity": "sha512-I7AIg5boAr5R0FFtJ6rCfD+LFsWHp81dolrFD8S79U9tb8Az2nGrJncnMSnys+bpQJfRUzqs9hnA81OAA3hCuQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "prettier": "bin/prettier.cjs"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
+      }
+    },
+    "node_modules/prettier-linter-helpers": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/prettier-linter-helpers/-/prettier-linter-helpers-1.0.0.tgz",
+      "integrity": "sha512-GbK2cP9nraSSUF9N2XwUwqfzlAFlMNYYl+ShE/V+H8a9uNl/oUqB1w2EL54Jh0OlyRSd8RfWYJ3coVS4TROP2w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-diff": "^1.1.2"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
     "node_modules/prisma": {
       "version": "6.12.0",
       "resolved": "https://registry.npmjs.org/prisma/-/prisma-6.12.0.tgz",
@@ -6222,6 +6308,22 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/synckit": {
+      "version": "0.11.8",
+      "resolved": "https://registry.npmjs.org/synckit/-/synckit-0.11.8.tgz",
+      "integrity": "sha512-+XZ+r1XGIJGeQk3VvXhT6xx/VpbHsRzsTkGgF6E5RX9TTXD0118l87puaEBZ566FhqblC6U0d4XnubznJDm30A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@pkgr/core": "^0.2.4"
+      },
+      "engines": {
+        "node": "^14.18.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/synckit"
       }
     },
     "node_modules/tar": {

--- a/backend/package.json
+++ b/backend/package.json
@@ -35,11 +35,14 @@
     "sqlite3": "^5.1.7"
   },
   "devDependencies": {
-    "@eslint/js": "^9.0.0",
-    "eslint": "^9.28.0",
+    "@eslint/js": "^9.31.0",
+    "eslint": "^9.31.0",
+    "eslint-config-prettier": "^10.1.5",
+    "eslint-plugin-prettier": "^5.5.1",
     "eslint-plugin-react": "^7.37.5",
     "globals": "^16.2.0",
     "nodemon": "^3.1.9",
+    "prettier": "^3.6.2",
     "prisma": "^6.12.0"
   }
 }

--- a/backend/package.json
+++ b/backend/package.json
@@ -25,7 +25,7 @@
     "@fastify/multipart": "^9.0.3",
     "@fastify/rate-limit": "^10.3.0",
     "@fastify/static": "^8.2.0",
-    "@prisma/client": "^6.11.1",
+    "@prisma/client": "^6.12.0",
     "bcryptjs": "^2.4.3",
     "dotenv": "^16.5.0",
     "fastify": "^5.2.2",
@@ -40,6 +40,6 @@
     "eslint-plugin-react": "^7.37.5",
     "globals": "^16.2.0",
     "nodemon": "^3.1.9",
-    "prisma": "^6.11.1"
+    "prisma": "^6.12.0"
   }
 }

--- a/backend/srcs/APItest/testAPI.http
+++ b/backend/srcs/APItest/testAPI.http
@@ -110,7 +110,7 @@ POST http://localhost:3000/auth/verify-tournamentOtp HTTP/1.1
 content-type: application/json
 
 {
-    "code": "162811",
+    "code": "839137",
     "email": "casi.lehtovuori@gmail.com"
 }
 ###

--- a/backend/srcs/APItest/testAPI.http
+++ b/backend/srcs/APItest/testAPI.http
@@ -83,25 +83,25 @@ content-type: application/json
 
 ###
 
-//GET TOURNAMENTS
-GET http://localhost:3000/tournaments HTTP/1.1
+//GET ALL TOURNAMENTS
+GET http://localhost:3000/tournaments/all HTTP/1.1
 ###
 //GET TOURNAMENT BY ID
-GET http://localhost:3000/tournaments/8 HTTP/1.1
+GET http://localhost:3000/tournaments/145 HTTP/1.1
 
 ###
 //start a  tournament
-POST http://localhost:3000/tournaments/2/start HTTP/1.1
+POST http://localhost:3000/tournaments/145/start HTTP/1.1
 
 ###
 
 //update a tournament match
-POST http://localhost:3000/tournaments/2/match/6/update HTTP/1.1
+POST http://localhost:3000/tournaments/145/match/3/update HTTP/1.1
 content-type: application/json
 
 {
     "winnerId": null,
-    "winnerAlias": "ccc"
+    "winnerAlias": "asd"
 }
 
 ###

--- a/backend/srcs/APItest/testAPI.http
+++ b/backend/srcs/APItest/testAPI.http
@@ -60,6 +60,17 @@ content-type: application/json
 DELETE http://localhost:3000/users/delete/9 HTTP/1.1
 
 ###
+//create a tournament
+POST http://localhost:3000/tournaments/create HTTP/1.1
+content-type: application/json
+
+{
+    "name": "sample tournament",
+    "size": 4,
+    "createdById": 1,
+    "status": "waiting"
+}
+###
 
 //ADD user to tournament
 POST http://localhost:3000/tournaments/1/register HTTP/1.1

--- a/backend/srcs/index.js
+++ b/backend/srcs/index.js
@@ -17,6 +17,7 @@ import rateLimit from "@fastify/rate-limit";
 import dotenv from "dotenv";
 import { matchesRoute } from "./routes/matches.js";
 import { tournamentsRoute } from "./routes/tournaments.js";
+
 const fastify = Fastify({ logger: true });
 
 const __filename = fileURLToPath(import.meta.url);
@@ -61,7 +62,9 @@ const start = async () => {
       },
     });
 
-    await fastify.register(rateLimit);
+    await fastify.register(rateLimit, {
+      global:false,
+    });
 
     //connect the routes to the backend
     fastify.register(userRoutes);

--- a/backend/srcs/middleware/devOnly.js
+++ b/backend/srcs/middleware/devOnly.js
@@ -1,9 +1,9 @@
 
 //This is a prehandler for restricting APIs to localhost only
 export async function devOnly(request, reply) {
-	  console.log("running devOnly middleware");
-	// Allow access only from localhost
-	if (request.ip !== "::1" && request.ip !== "127.0.0.1") {
-	  return reply.code(403).send({ error: "Access denied. This endpoint is only available from localhost." });
-	}
+  console.log("running devOnly middleware");
+  // Allow access only from localhost
+  if (request.ip !== "::1" && request.ip !== "127.0.0.1") {
+    return reply.code(403).send({ error: "Access denied. This endpoint is only available from localhost." });
+  }
 }

--- a/backend/srcs/middleware/devOnly.js
+++ b/backend/srcs/middleware/devOnly.js
@@ -1,0 +1,9 @@
+
+//This is a prehandler for restricting APIs to localhost only
+export async function devOnly(request, reply) {
+	  console.log("running devOnly middleware");
+	// Allow access only from localhost
+	if (request.ip !== "::1" && request.ip !== "127.0.0.1") {
+	  return reply.code(403).send({ error: "Access denied. This endpoint is only available from localhost." });
+	}
+}

--- a/backend/srcs/routes/otp.js
+++ b/backend/srcs/routes/otp.js
@@ -1,17 +1,11 @@
 import prisma from "../prisma.js";
 import bcryptjs from "bcryptjs";
-import ratelimit from "@fastify/rate-limit";
 import { handleOtp } from "../handleOtp.js";
 import { authenticate } from "../middleware/authenticate.js";
 import { authenticateOptional } from "../middleware/authenticateOptional.js";
 import { otpSchemas } from "../schemas/otpSchemas.js";
 export async function otpRoutes(fastify, _options) {
   //####################################################################################################################################
-
-  await fastify.register(ratelimit, {
-    global: false,
-  });
-
 
   // a rout for verifing the OTP witout making a cookie
   fastify.post(

--- a/backend/srcs/routes/otp.js
+++ b/backend/srcs/routes/otp.js
@@ -7,7 +7,7 @@ import { otpSchemas } from "../schemas/otpSchemas.js";
 export async function otpRoutes(fastify, _options) {
   //####################################################################################################################################
 
-  // a rout for verifing the OTP witout making a cookie
+  // a route for verifing the OTP witout making a cookie
   fastify.post(
     "/auth/otp/verify",
     { schema: otpSchemas.otpVerifyNoCoockieSchema, preHandler: authenticate },
@@ -147,7 +147,7 @@ export async function otpRoutes(fastify, _options) {
   fastify.post(
     "/auth/verify-tournamentOtp",
     { config: { rateLimit: { max: 10, timeWindow: "1 minute", keyGenerator: (req) => req.ip }},
-      /* schema: otpSchemas.otpVerifyWithCoockieSchema  */},
+      schema: otpSchemas.otpVerifyTournamentSchema },
     async (request, reply) => {
 
       const { code, email } = request.body;

--- a/backend/srcs/routes/tournaments.js
+++ b/backend/srcs/routes/tournaments.js
@@ -6,16 +6,24 @@ import { tournamentsSchemas } from "../schemas/tournamentsSchemas.js";
   need to make sure that too many tournaments cannot be created (some function for cleaning up database of old tournaments)
   same if the tournament creation is left undone */
 
-export async function tournamentsRoute(fastify, _options) {
+  
+  export async function tournamentsRoute(fastify, _options) {
+
+  //   await fastify.register(ratelimit, {
+  //   global: false,
+  // });
+
   // Create a tournament
   fastify.post("/tournaments/create",
     {
       schema: tournamentsSchemas.createTournamentSchema,
+      config: {rateLimit: { max: 10, timeWindow: "1 minute", keyGenerator: (req) => req.ip, }}
       // commented out in order to allow unauthenticated users to create tournaments
       // preHandler: authenticate,
     },
     async (req, reply) => {
       const { name, size, createdById, status } = req.body;
+
       console.log("Creating tournament with data:", req.body);
       //the schema already validates and returns 400 if not the right size
       // if (![4, 8, 16, 32].includes(size)) return reply.code(400).send({ error: 'Invalid size' });

--- a/backend/srcs/routes/users.js
+++ b/backend/srcs/routes/users.js
@@ -305,6 +305,7 @@ export async function userRoutes(fastify, _options) {
 
         return reply.code(200).send({ message: "Password reset successfully" });
       } catch (error) {
+        console.error("Reset password error:", error);
         return reply.code(400).send({ error: "Invalid or expired token" });
       }
     }

--- a/backend/srcs/schemas/otpSchemas.js
+++ b/backend/srcs/schemas/otpSchemas.js
@@ -35,6 +35,25 @@ const otpVerifyWithCoockieSchema = {
   },
 };
 
+const otpVerifyTournamentSchema = {
+  body: {
+    type: "object",
+    properties: {
+      code: { type: "string", minLength: 6, maxLength: 6 },
+      email: { type: "string", format: "email" },
+    },
+    required: ["code", "email"],
+  },
+  response: {
+    200: { type: "object", properties: { message: { type: "string" } } },
+    400: { type: "object", properties: { error: { type: "string" } } },
+    403: { type: "object", properties: { error: { type: "string" } } },
+    401: { type: "object", properties: { error: { type: "string" } } },
+    404: { type: "object", properties: { error: { type: "string" } } },
+    500: { type: "object", properties: { error: { type: "string" } } },
+  },
+};
+
 const otpWaitSchema = {
   response: {
     200: {
@@ -62,6 +81,7 @@ const otpSendSchema = {
 };
 
 export const otpSchemas = {
+  otpVerifyTournamentSchema,
   otpVerifyNoCoockieSchema,
   otpVerifyWithCoockieSchema,
   otpWaitSchema,

--- a/backend/srcs/schemas/tournamentsSchemas.js
+++ b/backend/srcs/schemas/tournamentsSchemas.js
@@ -10,7 +10,37 @@ const participantSchema = {
     alias: { type: ["string", "null"] },
     joinedAt: { type: "string", format: "date-time" },
   },
-  required: ["id", "tournamentId", "userId", "alias", "joinedAt"],
+/*   required: ["id", "tournamentId", "userId", "alias", "joinedAt"], */
+};
+
+const tournamentMatchSchema = {
+  type: "object",
+  properties: {
+    id: { type: "integer" },
+    tournamentId: { type: "integer" },
+    round: { type: "integer" },
+    player1Id: { type: ["integer", "null"] },
+    player1Alias: { type: ["string", "null"] },
+    player2Id: { type: ["integer", "null"] },
+    player2Alias: { type: ["string", "null"] },
+    winnerId: { type: ["integer", "null"] },
+    winnerAlias: { type: ["string", "null"] },
+    status: { type: "string", enum: ["waiting", "in_progress", "completed", "archived"] },
+    createdAt: { type: "string", format: "date-time" },
+    updatedAt: { type: "string", format: "date-time" },
+  },
+/*   required: [
+    "id",
+    "tournamentId",
+    "round",
+    "player1Id",
+    "player1Alias",
+    "player2Id",
+    "player2Alias",
+    "winnerId",
+    "winnerAlias",
+    "status",
+  ], */
 };
 
 // Schema for creating a tournament
@@ -37,13 +67,13 @@ const createTournamentSchema = {
         createdById: { type: "integer" },
         status: { type: "string", enum: ["waiting"] },
       },
-      required: [
+/*       required: [
         "id",
         "name",
         "size",
         // "createdById",
         "status",
-      ],
+      ], */
     },
     400: {
       type: "object",
@@ -76,6 +106,10 @@ const registerTournamentSchema = {
       alias: { type: "string" },
     },
     additionalProperties: false,
+    anyOf: [
+      {required: ["userId"] },
+      {required: ["alias"] },
+    ]
   },
   response: {
     200: participantSchema,
@@ -103,8 +137,7 @@ const registerTournamentSchema = {
 
 // Schema for listing all tournaments
 const getAllTournamentsSchema = {
-  $id: "getTournamentsSchema",
-  description: "Get all tournaments (with participants)",
+  description: "Get all tournaments (with participants and matches)",
   tags: ["tournaments"],
   response: {
     200: {
@@ -120,17 +153,19 @@ const getAllTournamentsSchema = {
           createdAt: { type: "string", format: "date-time" },
           updatedAt: { type: "string", format: "date-time" },
           participants: { type: "array", items: participantSchema },
+          tournamentMatches: {
+            type: "array",
+            items: tournamentMatchSchema ,
+          }
         },
-        required: [
+/*         required: [
           "id",
           "name",
           "size",
           "createdById",
           "status",
-          "createdAt",
-          "updatedAt",
           "participants",
-        ],
+        ], */
       },
     },
     500: {
@@ -141,7 +176,7 @@ const getAllTournamentsSchema = {
   },
 };
 
-// Schema for fetching a single tournament by ID
+//Schema for fetching a single tournament by ID
 const getTournamentSchema = {
   description: "Get a single tournament by ID (with participants & matches)",
   tags: ["tournaments"],
@@ -163,23 +198,22 @@ const getTournamentSchema = {
         status: { type: "string" },
         createdAt: { type: "string", format: "date-time" },
         updatedAt: { type: "string", format: "date-time" },
+        winnerId: { type: ["integer", "null"] },
+        winnerAlias: { type: ["string", "null"] },
         participants: { type: "array", items: participantSchema },
-        matches: {
+        tournamentMatches: {
           type: "array",
-          items: { type: "object", additionalProperties: true },
+          items: tournamentMatchSchema,
         },
       },
-      required: [
+/*       required: [
         "id",
         "name",
         "size",
-        "createdById",
         "status",
-        "createdAt",
-        "updatedAt",
         "participants",
-        "matches",
-      ],
+        "tournamentMatches",
+      ], */
     },
     404: {
       type: "object",
@@ -196,7 +230,116 @@ const getTournamentSchema = {
   },
 };
 
+// schema for starting a tournament
+const startTournamentSchema = {
+  description: "Start a tournament",
+  tags: ["tournaments"],
+  params: {
+    type: "object",
+    properties: {
+      id: { type: "integer", minimum: 1 },
+    },
+    required: ["id"],
+  },
+  response: {
+    200: {
+      type: "object",
+      properties: {
+        id: { type: "integer" },
+        name: { type: "string" },
+        size: { type: "integer" },
+        createdById: { type: "integer" },
+        status: { type: "string", enum: ["in_progress"] },
+        createdAt: { type: "string", format: "date-time" },
+        updatedAt: { type: "string", format: "date-time" },
+        participants: {
+          type: "array",
+          items: participantSchema,
+        },
+        tournamentMatches: {
+          type: "array",
+          items: tournamentMatchSchema,
+      }},
+/*       required: [
+        "id", 
+        "name", 
+        "size", 
+        "createdById", 
+        "status", 
+        "participants", 
+        "tournamentMatches"
+      ], */
+    },
+    400: {
+      type: "object",
+      properties: {
+        message: { type: "string", example: "Invalid tournament ID" },
+      },
+      required: ["message"],
+    },
+    404: {
+      type: "object",
+      properties: {
+        message: { type: "string", example: "Tournament not found" },
+      },
+      required: ["message"],
+    },
+    500: {
+      type: "object",
+      properties: { message: { type: "string", example: "Server error" } },
+      required: ["message"],
+    },
+  },
+};
+
+//scheam for updating a tournament match
+const updateTournamentMatchSchema = {
+  description: "Update a tournament match",
+  tags: ["tournaments"],
+  params: {
+    type: "object",
+    properties: {
+      id: { type: "integer", minimum: 1 },
+      matchId: { type: "integer", minimum: 1 },
+    },
+    required: ["id", "matchId"],
+  },
+  body: {
+    type: "object",
+    properties: {
+      winnerId: { type: ["integer", "null"] },
+      winnerAlias: { type: ["string", "null"] },
+    }
+  },
+  response: {
+  200: {
+    ...tournamentMatchSchema,
+  },
+  400: {
+    type: "object",
+    properties: {
+      message: { type: "string", example: "Invalid match ID" },
+    },
+    required: ["message"],
+  },
+  404: {
+    type: "object",
+    properties: {
+      message: { type: "string", example: "Match not found" },
+    },
+    required: ["message"],
+  },
+  500: {
+    type: "object",
+    properties: { message: { type: "string", example: "Server error" } },
+    required: ["message"],
+  },
+}};
+  
+
 export const tournamentsSchemas = {
+  updateTournamentMatchSchema,
+  startTournamentSchema,
   createTournamentSchema,
   registerTournamentSchema,
   getAllTournamentsSchema,


### PR DESCRIPTION
This pull request introduces several updates to the backend, including enhancements to tournament-related functionality, middleware improvements, and dependency updates. The most significant changes involve adding rate-limiting and localhost restrictions for certain routes, updating Prisma dependencies, and refining tournament schemas and APIs.

### Backend Functionality Enhancements:
* Added a new `devOnly` middleware to restrict access to specific routes from localhost only. This is applied to the `/tournaments/all` route for development purposes. 
* Introduced rate-limiting configuration for the `/tournaments/create` route to limit tournament creation requests to 10 per minute per IP. (`backend/srcs/routes/tournaments.js`
* Updated the tournament match update logic to ensure matches can only be updated if they are in a "pending" state. 

### API and Schema Refinements:
* Added schemas for the rest of the tournament API's, and also the no cookie otp API

### Miscellaneous Changes:
* Added a new `deepclean` target to the `Makefile` for cleaning Docker configurations and removing `node_modules`. 
* Updated fclean to only remove containers named "frontend" and "backend"
* Registered `rateLimit` globally with the `global: false` option in the backend to improve rate-limiting configuration. 