### PR TITLE
Tournament deletion

### DIFF
--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -111,7 +111,7 @@ model Tournament {
 
 model TournamentParticipant {
   id           Int        @id @default(autoincrement())
-  tournament   Tournament @relation(fields: [tournamentId], references: [id])
+  tournament   Tournament @relation(fields: [tournamentId], references: [id], onDelete: Cascade)
   tournamentId Int
   user         User?      @relation(fields: [userId], references: [id])
   userId       Int?
@@ -121,7 +121,7 @@ model TournamentParticipant {
 
 model TournamentMatch {
   id           Int        @id @default(autoincrement())
-  tournament   Tournament @relation(fields: [tournamentId], references: [id])
+  tournament   Tournament @relation(fields: [tournamentId], references: [id], onDelete: Cascade)
   tournamentId Int
 
   round Int

--- a/backend/srcs/APItest/testAPI.http
+++ b/backend/srcs/APItest/testAPI.http
@@ -121,9 +121,10 @@ content-type: application/json
     "password": "42"
 }
 ###
+//Delete a tournament with id + name
+DELETE http://localhost:3000/tournaments/147/Pong%20Tournament HTTP/1.1
 
-
-
+###
 
 
 

--- a/backend/srcs/APItest/testAPI.http
+++ b/backend/srcs/APItest/testAPI.http
@@ -122,7 +122,7 @@ content-type: application/json
 }
 ###
 //Delete a tournament with id + name
-DELETE http://localhost:3000/tournaments/147/Pong%20Tournament HTTP/1.1
+DELETE http://localhost:3000/tournaments/145/Pong%20Tournament HTTP/1.1
 
 ###
 

--- a/backend/srcs/routes/tournaments.js
+++ b/backend/srcs/routes/tournaments.js
@@ -236,14 +236,12 @@ import { devOnly } from "../middleware/devOnly.js";
     }
   );
 
-}
-
 //##############################################################
 
 //Route to delete a tournament
 //Requires both tournament ID and Name for security resons
 fastify.delete(
-  "/tournaments/:id",
+  "/tournaments/:id/:name",
   { schema: tournamentsSchemas.deleteTournamentSchema, 
     config: { ratelimit: {max: 20, timeWindow: "1 minute", keyGenerator: (req) => req.ip}} 
   },
@@ -254,6 +252,7 @@ fastify.delete(
       const tournament = await prisma.tournament.findUnique({
         where: { id: Number(id) },
       });
+      console.log("name:", name, "tournament name:", tournament.name);
       if (!tournament || name !== tournament.name) {
         return reply.code(404).send({ message: "Tournament not found" });
       }
@@ -266,7 +265,7 @@ fastify.delete(
       return reply.code(500).send({ error: "Unable to delete tournament"});
     }
   });
-
+}
 //################################################################
 
 // Function to check if all matches in a tournament are completed

--- a/backend/srcs/schemas/tournamentsSchemas.js
+++ b/backend/srcs/schemas/tournamentsSchemas.js
@@ -336,6 +336,40 @@ const updateTournamentMatchSchema = {
   },
 }};
   
+//schema for deleting a tournament
+const deleteTournamentSchema = {
+  description: "Delete a tournament",
+  tags: ["tournaments"],
+  params: {
+    type: "object",
+    properties: {
+      id: { type: "integer", minimum: 1 },
+      name: { type: "string" },
+    },
+    required: ["id", "name"],
+  },
+  response: {
+    200: {
+      type: "object",
+      properties: {
+        message: { type: "string", example: "Tournament deleted successfully" },
+      },
+      required: ["message"],
+    },
+    404: {
+      type: "object",
+      properties: {
+        message: { type: "string", example: "Tournament not found" },
+      },
+      required: ["message"],
+    },
+    500: {
+      type: "object",
+      properties: { message: { type: "string", example: "Server error" } },
+      required: ["message"],
+    },
+  },
+};
 
 export const tournamentsSchemas = {
   updateTournamentMatchSchema,

--- a/backend/srcs/schemas/tournamentsSchemas.js
+++ b/backend/srcs/schemas/tournamentsSchemas.js
@@ -372,6 +372,7 @@ const deleteTournamentSchema = {
 };
 
 export const tournamentsSchemas = {
+  deleteTournamentSchema,
   updateTournamentMatchSchema,
   startTournamentSchema,
   createTournamentSchema,


### PR DESCRIPTION
This pull request introduces a new feature to delete tournaments securely while also improving database integrity and adding corresponding API and schema updates. The most significant changes include adding a `DELETE` route for tournaments, defining a schema for the deletion process, and updating the database relations to handle cascading deletions.

### New Feature: Tournament Deletion

* **Route for deleting tournaments**: Added a `DELETE` endpoint (`/tournaments/:id/:name`) that requires both the tournament ID and name for security. The route includes validation, logging, and error handling to ensure robust functionality.
* **Schema for delete endpoint**: Introduced `deleteTournamentSchema` to validate the parameters and responses for the new delete route. This ensures the API adheres to a consistent structure.

### Database Integrity Improvements

* **Cascade deletion in `TournamentParticipant`**: Updated the `tournament` relation in the `TournamentParticipant` model to include `onDelete: Cascade`, ensuring related participants are removed when a tournament is deleted.
* **Cascade deletion in `TournamentMatch`**: Updated the `tournament` relation in the `TournamentMatch` model to include `onDelete: Cascade`, ensuring related matches are removed when a tournament is deleted.

### Testing Updates

* **API test for deletion**: Added a test case in `testAPI.http` to validate the functionality of the new delete endpoint by simulating a deletion request.