### PR TITLE
added Database cleaner

### DIFF
--- a/backend/srcs/index.js
+++ b/backend/srcs/index.js
@@ -17,6 +17,7 @@ import rateLimit from "@fastify/rate-limit";
 import dotenv from "dotenv";
 import { matchesRoute } from "./routes/matches.js";
 import { tournamentsRoute } from "./routes/tournaments.js";
+import { startDBCleaner } from "./utils/DBCleaner.js";
 
 const fastify = Fastify({ logger: true });
 
@@ -89,6 +90,10 @@ const start = async () => {
 
     await fastify.listen({ port: 3000, host: "0.0.0.0" });
     console.log("Server listening on http://localhost:3000");
+
+    // Start the database cleaner
+    startDBCleaner(60 * 60 * 1000); // runs every hour
+
   } catch (err) {
     console.log("Catch activated!!");
     fastify.log.error(err);

--- a/backend/srcs/utils/DBCleaner.js
+++ b/backend/srcs/utils/DBCleaner.js
@@ -1,0 +1,33 @@
+//A recurrently running function which cleans up the database
+import prisma from "../prisma.js";
+
+
+async function DBCleaner() {
+	console.log("[DBCleaner] Executing DB cleanup");
+	// Get a 6h old timestamp
+	const sixHourAgo = new Date(Date.now() - 6 * 60 * 60 * 1000);
+	try {
+		//check for tournaments that are older than 6 hours and delete them
+		const deletedTournaments = await prisma.tournament.deleteMany({
+			where: {
+				updatedAt: { lt: sixHourAgo }
+			}
+		})
+		console.log(`[DBCleaner] deleted ${deletedTournaments.count} old tournaments`)
+		//check for expired OTPs
+		const deletedOtps = await prisma.otp.deleteMany({
+			where: { expiresAt: { lt: new Date() }
+			}
+		})
+		console.log(`[DBCleaner] deleted ${deletedOtps.count} old OTPs`)
+
+	} catch(error) {
+		console.error("[DBCleaner] DB cleanup failed: ", error);
+	}
+}
+
+export function startDBCleaner(intervalMS = 60 * 60 * 1000) {
+	console.log(`[DBCleaner] started`)
+	DBCleaner();
+	setInterval(DBCleaner, intervalMS);
+}


### PR DESCRIPTION
This pull request introduces a database cleanup utility to ensure outdated data is periodically removed. The most important changes include adding the `DBCleaner` utility, integrating it into the server startup process, and defining its functionality to clean up old tournaments and expired OTPs.

### Database Cleanup Utility:

* [`backend/srcs/utils/DBCleaner.js`](diffhunk://#diff-6a7fb2ec13cf162877f88d9515c53f6375e1a1caafc362c8f1828ab7d6e9837aR1-R33): Added a new utility, `DBCleaner`, which removes tournaments older than 6 hours and expired OTPs from the database. It logs the results of each cleanup operation and errors if they occur. The `startDBCleaner` function initializes the cleanup process and schedules it to run at a specified interval (default: 1 hour).

### Integration with Server:

* `backend/srcs/index.js`: 
  - Imported the `startDBCleaner` function from `DBCleaner.js`.
  - Integrated `startDBCleaner` into the server startup process to ensure the cleanup runs automatically after the server starts.