### PR TITLE
added translations for GameCustomization, MatchCard and PongGame components

### DIFF
--- a/frontend/react/src/components/GameCustomization.tsx
+++ b/frontend/react/src/components/GameCustomization.tsx
@@ -58,14 +58,14 @@ const GameCustomization: React.FC<GameCustomizationProps> = ({
   return (
     <div className="max-w-2xl mx-auto p-6 bg-white dark:bg-gray-800 rounded-lg shadow-lg">
       <h2 className="text-3xl font-bold text-center text-teal-700 dark:text-teal-300 mb-6">
-        Game Customization
+        {t("gamecustomization.title")}
       </h2>
 
       <div className="space-y-6">
         {/* Score to Win */}
         <div>
           <label className={labelStyles} htmlFor="scoreToWin">
-            Score to Win: {settings.scoreToWin}
+            {t("gamecustomization.scoreToWin")}: {settings.scoreToWin}
           </label>
           <input
             type="range"
@@ -87,7 +87,7 @@ const GameCustomization: React.FC<GameCustomizationProps> = ({
         {isAIGame && (
           <div>
             <label className={labelStyles} htmlFor="aiDifficulty">
-              AI Difficulty
+              {t("gamecustomization.aiDifficulty")}
             </label>
             <select
               id="aiDifficulty"
@@ -95,10 +95,18 @@ const GameCustomization: React.FC<GameCustomizationProps> = ({
               onChange={handleDifficultyChange}
               className={inputStyles + " w-full"}
             >
-              <option value="easy">Easy - AI makes many mistakes</option>
-              <option value="medium">Medium - Balanced gameplay</option>
-              <option value="hard">Hard - Challenging opponent</option>
-              <option value="expert">Expert - Nearly perfect AI</option>
+              <option value="easy">
+                {t("gamecustomization.difficulty.easy")}
+              </option>
+              <option value="medium">
+                {t("gamecustomization.difficulty.medium")}
+              </option>
+              <option value="hard">
+                {t("gamecustomization.difficulty.hard")}
+              </option>
+              <option value="expert">
+                {t("gamecustomization.difficulty.expert")}
+              </option>
             </select>
           </div>
         )}
@@ -106,7 +114,7 @@ const GameCustomization: React.FC<GameCustomizationProps> = ({
         {/* Map Selection */}
         <div>
           <label className={labelStyles} htmlFor="mapType">
-            Map Type
+            {t("gamecustomization.mapType")}
           </label>
           <select
             id="mapType"
@@ -114,12 +122,14 @@ const GameCustomization: React.FC<GameCustomizationProps> = ({
             onChange={handleMapChange}
             className={inputStyles + " w-full"}
           >
-            <option value="classic">Classic - Standard Pong</option>
+            <option value="classic">
+              {t("gamecustomization.map.classic")}
+            </option>
             <option value="corners">
-              Corner Walls - Score only through center
+              {t("gamecustomization.map.corners")}
             </option>
             <option value="center-wall">
-              Center Wall - Ball goes top/bottom only
+              {t("gamecustomization.map.centerWall")}
             </option>
           </select>
         </div>
@@ -127,7 +137,7 @@ const GameCustomization: React.FC<GameCustomizationProps> = ({
         {/* Ball Speed Selection - Slider */}
         <div>
           <label className={labelStyles} htmlFor="ballSpeed">
-            Ball Speed: {settings.ballSpeed}/10
+            {t("gamecustomization.ballSpeed")}: {settings.ballSpeed}/10
           </label>
           <input
             id="ballSpeed"
@@ -142,19 +152,19 @@ const GameCustomization: React.FC<GameCustomizationProps> = ({
             className="w-full h-2 bg-gray-200 rounded-lg appearance-none cursor-pointer dark:bg-gray-700"
           />
           <div className="flex justify-between text-xs text-gray-500 dark:text-gray-400 mt-1">
-            <span>Slow</span>
-            <span>Medium</span>
-            <span>Fast</span>
-            <span>Extreme</span>
+            <span>{t("gamecustomization.speed.slow")}</span>
+            <span>{t("gamecustomization.speed.medium")}</span>
+            <span>{t("gamecustomization.speed.fast")}</span>
+            <span>{t("gamecustomization.speed.extreme")}</span>
           </div>
           <p className="text-xs text-gray-500 dark:text-gray-400 mt-2">
             {settings.ballSpeed <= 3
-              ? "Beginner friendly - Plenty of time to react"
+              ? t("gamecustomization.speedDescription.easy")
               : settings.ballSpeed <= 6
-              ? "Balanced - Good for standard gameplay"
+              ? t("gamecustomization.speedDescription.medium")
               : settings.ballSpeed <= 8
-              ? "Challenging - Test your reflexes"
-              : "Extreme - For Pong masters only!"}
+              ? t("gamecustomization.speedDescription.hard")
+              : t("gamecustomization.speedDescription.extreme")}
           </p>
         </div>
 
@@ -162,7 +172,7 @@ const GameCustomization: React.FC<GameCustomizationProps> = ({
         <div className="border-t border-gray-200 dark:border-gray-600 pt-4">
           <div className="flex items-center justify-between mb-4">
             <label htmlFor="togglePowerUpsCheckbox" className="text-lg font-semibold text-gray-700 dark:text-gray-300">
-              Power-ups
+              {t("gamecustomization.powerUps.title")}
             </label>
             <div className="flex items-center cursor-pointer">
               <input
@@ -193,10 +203,10 @@ const GameCustomization: React.FC<GameCustomizationProps> = ({
               <div className="flex items-center justify-between">
                 <div>
                   <span className="font-medium text-gray-700 dark:text-gray-300">
-                    🏓 Big Paddle
+                    🏓 {t("gamecustomization.powerUps.bigPaddle")}
                   </span>
                   <p className="text-sm text-gray-500 dark:text-gray-400">
-                    Enlarges paddle for 8 seconds
+                    {t("gamecustomization.powerUps.description")}
                   </p>
                 </div>
                 <label className="flex items-center cursor-pointer">
@@ -236,7 +246,7 @@ const GameCustomization: React.FC<GameCustomizationProps> = ({
             }}
 			className={altButtonStyles}
           >
-            Reset to Defaults
+            {t("gamecustomization.reset")}
           </button>
             <button
               onClick={() => {
@@ -245,7 +255,7 @@ const GameCustomization: React.FC<GameCustomizationProps> = ({
               }}
 			  className={altButtonStyles}
 			 >
-              Back
+               {t("gamecustomization.back")}
             </button>
             <button
               onClick={() => {
@@ -257,7 +267,7 @@ const GameCustomization: React.FC<GameCustomizationProps> = ({
               }}
               className={buttonStyles}
             >
-              Start Game
+              {t("gamecustomization.start")}
             </button>
           
         </div>

--- a/frontend/react/src/components/MatchCard.tsx
+++ b/frontend/react/src/components/MatchCard.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import { Match, Player } from "../types/game";
+import { useTranslation } from "react-i18next";
 
 interface MatchCardProps {
   match: Match;
@@ -8,6 +9,7 @@ interface MatchCardProps {
 
 const MatchCard: React.FC<MatchCardProps> = ({ match, onPlay }) => {
   const { player1, player2, result, winnerId } = match;
+  const { t } = useTranslation();
 
   return (
     <div className="flex justify-between items-center p-3 border rounded mb-2">
@@ -17,7 +19,7 @@ const MatchCard: React.FC<MatchCardProps> = ({ match, onPlay }) => {
       </div>
       {result ? (
         <div className="text-green-600 font-semibold">
-          Winner: {winnerId === player1.id ? player1.name : player2.name}
+          {t("matchcard.winner")}: {winnerId === player1.id ? player1.name : player2.name}
         </div>
       ) : (
         <div className="flex gap-2">
@@ -25,13 +27,13 @@ const MatchCard: React.FC<MatchCardProps> = ({ match, onPlay }) => {
             className="bg-blue-600 text-white px-3 py-1 rounded"
             onClick={() => onPlay(match, player1)}
           >
-            {player1.name} Wins
+            {t("matchcard.win", { name: player1.name })}
           </button>
           <button
             className="bg-blue-600 text-white px-3 py-1 rounded"
             onClick={() => onPlay(match, player2)}
           >
-            {player2.name} Wins
+            {t("matchcard.win", { name: player2.name })}
           </button>
         </div>
       )}

--- a/frontend/react/src/components/PongGame.tsx
+++ b/frontend/react/src/components/PongGame.tsx
@@ -1,6 +1,7 @@
 import api from '../api/axios';
 import React, { useRef, useEffect, useState } from 'react';
 import { useGameSettings, getDifficultySettings, DifficultySettings, GameSettings } from '../contexts/GameSettingsContext';
+import { useTranslation } from "react-i18next";
 
 // Game constants for consistent physics
 // Ball speed is calculated based on the slider value (1-10)
@@ -570,6 +571,7 @@ const PongGame: React.FC<PongGameProps> = ({ player1, player2, isAIGame, onRetur
   const [isFocused, setIsFocused] = useState(false);
   const [isPaused, setIsPaused] = useState(false);
   const { settings } = useGameSettings();
+  const { t } = useTranslation();
   
   console.log("PongGame: Using game settings", settings);
 
@@ -919,12 +921,12 @@ const PongGame: React.FC<PongGameProps> = ({ player1, player2, isAIGame, onRetur
         
         if (player1PowerUpsRef.current.paddleEnlarge.active) {
           const timeLeft = Math.max(0, (player1PowerUpsRef.current.paddleEnlarge.endTime - Date.now()) / 1000);
-          ctx.fillText(`Big Paddle: ${timeLeft.toFixed(1)}s`, 20, canvasHeight - 20);
+          ctx.fillText(`${t("powerups.bigPaddle")}: ${timeLeft.toFixed(1)}s`, 20, canvasHeight - 20);
         }
         
         if (player2PowerUpsRef.current.paddleEnlarge.active) {
           const timeLeft = Math.max(0, (player2PowerUpsRef.current.paddleEnlarge.endTime - Date.now()) / 1000);
-          ctx.fillText(`Big Paddle: ${timeLeft.toFixed(1)}s`, canvasWidth - 120, canvasHeight - 20);
+          ctx.fillText(`${t("powerups.bigPaddle")}: ${timeLeft.toFixed(1)}s`, canvasWidth - 120, canvasHeight - 20);
         }
         
         ctx.restore();
@@ -1555,7 +1557,7 @@ const PongGame: React.FC<PongGameProps> = ({ player1, player2, isAIGame, onRetur
         }}
       >
         <span className="dark:text-white text-black">{player1.username}</span>
-        <div className="text-xs text-gray-500 dark:text-gray-400">Press 'P' to pause/unpause</div>
+        <div className="text-xs text-gray-500 dark:text-gray-400">{t("pongGame.pressPToPause")}</div>
         <span className="dark:text-white text-black">{player2.username}</span>
       </div>
       
@@ -1565,8 +1567,8 @@ const PongGame: React.FC<PongGameProps> = ({ player1, player2, isAIGame, onRetur
           <div className="absolute inset-0 flex items-center justify-center z-20 bg-black bg-opacity-40 cursor-pointer"
                onClick={() => canvasRef.current?.focus()}>
             <div className="bg-blue-900 bg-opacity-80 px-6 py-4 rounded-lg text-white font-bold text-center animate-pulse">
-              Click to play<br/>
-              <span className="text-sm text-blue-200">Game controls only work when focused</span>
+              {t("pongGame.clickToPlay")}<br/>
+              <span className="text-sm text-blue-200">{t("pongGame.controlsWorkWhenFocused")}</span>
             </div>
           </div>
         )}
@@ -1575,8 +1577,8 @@ const PongGame: React.FC<PongGameProps> = ({ player1, player2, isAIGame, onRetur
         {isPaused && isFocused && (
           <div className="absolute inset-0 flex items-center justify-center z-20 bg-black bg-opacity-40">
             <div className="bg-purple-900 bg-opacity-80 px-8 py-6 rounded-lg text-white font-bold text-center">
-              GAME PAUSED<br/>
-              <span className="text-sm text-purple-200 mt-2 block">Press 'P' to resume</span>
+              {t("pongGame.gamePaused")}<br/>
+              <span className="text-sm text-purple-200 mt-2 block">{t("pongGame.pressPToResume")}</span>
             </div>
           </div>
         )}
@@ -1611,20 +1613,20 @@ const PongGame: React.FC<PongGameProps> = ({ player1, player2, isAIGame, onRetur
             zIndex: 10, // Ensure it's above the canvas
           }}
         >
-          <div className="mb-8">{winner} wins!</div>
+          <div className="mb-8">{t("pongGame.winnerMessage", { winner })}</div>
           <div className="flex flex-col gap-4 w-64">
             <button
               className="px-6 py-3 bg-teal-700 hover:bg-teal-600 text-white rounded-lg text-xl font-bold transition-colors"
               onClick={handleRestart}
             >
-              Restart Match
+              {t("pongGame.restartMatch")}
             </button>
             <button
               className="text-white bg-amber-700 hover:bg-amber-800 focus:ring-4 focus:outline-none focus:ring-blue-300 font-semibold rounded-lg text-sm w-full sm:w-auto px-11 py-3 mx-3 my-3 text-center dark:bg-amber-600 dark:hover:bg-amber-700 dark:focus:ring-amber-800"
 
               onClick={handleReturnToMenu}
             >
-              Return to Main Menu
+              {t("pongGame.returnToMainMenu")}
             </button>
           </div>
         </div>

--- a/frontend/react/src/translations/en.json
+++ b/frontend/react/src/translations/en.json
@@ -200,5 +200,60 @@
     "errorAllPlayersRequired": "All players must enter a username.",
     "errorTournamentCreation": "Error creating tournament.",
     "consoleCreating": "Let's make a tournament"
+  },
+  "gamecustomization": {
+    "title": "Game Customization",
+    "scoreToWin": "Score to Win",
+    "aiDifficulty": "AI Difficulty",
+    "difficulty": {
+      "easy": "Easy - AI makes many mistakes",
+      "medium": "Medium - Balanced gameplay",
+      "hard": "Hard - Challenging opponent",
+      "expert": "Expert - Nearly perfect AI"
+    },
+    "mapType": "Map Type",
+    "map": {
+      "classic": "Classic - Standard Pong",
+      "corners": "Corner Walls - Score only through center",
+      "centerWall": "Center Wall - Ball goes top/bottom only"
+    },
+    "ballSpeed": "Ball Speed",
+    "speed": {
+      "slow": "Slow",
+      "medium": "Medium",
+      "fast": "Fast",
+      "extreme": "Extreme"
+    },
+    "speedDescription": {
+      "easy": "Beginner friendly - Plenty of time to react",
+      "medium": "Balanced - Good for standard gameplay",
+      "hard": "Challenging - Test your reflexes",
+      "extreme": "Extreme - For Pong masters only!"
+    },
+    "powerUps": {
+      "title": "Power-ups",
+      "bigPaddle": "Big Paddle",
+      "description": "Enlarges paddle for 8 seconds"
+    },
+    "reset": "Reset to Defaults",
+    "back": "Back",
+    "start": "Start Game"
+  },
+  "matchcard": {
+    "winner": "Winner",
+    "win": "{{name}} Wins"
+  },
+  "powerups": {
+    "bigPaddle": "Big Paddle"
+  },
+  "pongGame": {
+    "pressPToPause": "Press 'P' to pause/unpause",
+    "clickToPlay": "Click to play",
+    "controlsWorkWhenFocused": "Game controls only work when focused",
+    "gamePaused": "GAME PAUSED",
+    "pressPToResume": "Press 'P' to resume",
+    "winnerMessage": "{{winner}} wins!",
+    "restartMatch": "Restart Match",
+    "returnToMainMenu": "Return to Main Menu"
   }
 }

--- a/frontend/react/src/translations/fi.json
+++ b/frontend/react/src/translations/fi.json
@@ -201,5 +201,60 @@
     "errorAllPlayersRequired": "Kaikkien pelaajien on annettava käyttäjänimi.",
     "errorTournamentCreation": "Turnauksen luominen epäonnistui.",
     "consoleCreating": "Luodaan turnaus"
+  },
+  "gamecustomization": {
+    "title": "Pelin mukautus",
+    "scoreToWin": "Pisteet voittoon",
+    "aiDifficulty": "Tietokoneen vaikeustaso",
+    "difficulty": {
+      "easy": "Helppo – Tekoäly tekee paljon virheitä",
+      "medium": "Keskitaso – Tasapainoinen peli",
+      "hard": "Vaikea – Haastava vastustaja",
+      "expert": "Ekspertti – Lähes virheetön tekoäly"
+    },
+    "mapType": "Kentän tyyppi",
+    "map": {
+      "classic": "Klassinen – Tavallinen Pong",
+      "corners": "Kulmaseinät – Maalit vain keskeltä",
+      "centerWall": "Keskiseinä – Pallo liikkuu vain ylös/alas"
+    },
+    "ballSpeed": "Pallon nopeus",
+    "speed": {
+      "slow": "Hidas",
+      "medium": "Keskitaso",
+      "fast": "Nopea",
+      "extreme": "Äärimmäinen"
+    },
+    "speedDescription": {
+      "easy": "Sopii aloittelijoille – Reaktioaikaa riittää",
+      "medium": "Tasapainoinen – Hyvä peruspeliin",
+      "hard": "Haastava – Testaa refleksit",
+      "extreme": "Äärimmäinen – Vain mestareille!"
+    },
+    "powerUps": {
+      "title": "Tehosteet",
+      "bigPaddle": "Suuri maila",
+      "description": "Suurentaa mailaa 8 sekunniksi"
+    },
+    "reset": "Palauta oletusasetukset",
+    "back": "Takaisin",
+    "start": "Aloita peli"
+  },
+  "matchcard": {
+    "winner": "Voittaja",
+    "win": "{{name}} voitti"
+  },
+  "powerups": {
+    "bigPaddle": "Iso Maila"
+  },
+  "pongGame": {
+    "pressPToPause": "Paina 'P' keskeyttääksesi/jatkaaksesi",
+    "clickToPlay": "Klikkaa pelataksesi",
+    "controlsWorkWhenFocused": "Pelin ohjaimet toimivat vain, kun peli on valittuna",
+    "gamePaused": "PELI TAUOLLA",
+    "pressPToResume": "Paina 'P' jatkaaksesi",
+    "winnerMessage": "{{winner}} voitti!",
+    "restartMatch": "Aloita Uudelleen",
+    "returnToMainMenu": "Palaa Päävalikkoon"
   }
 }

--- a/frontend/react/src/translations/se.json
+++ b/frontend/react/src/translations/se.json
@@ -201,5 +201,60 @@
     "errorAllPlayersRequired": "Alla spelare måste ange ett användarnamn.",
     "errorTournamentCreation": "Fel vid skapande av turnering.",
     "consoleCreating": "Skapar turnering"
+  },
+  "gamecustomization": {
+    "title": "Spelanpassning",
+    "scoreToWin": "Poäng för att vinna",
+    "aiDifficulty": "AI-svårighetsgrad",
+    "difficulty": {
+      "easy": "Lätt – AI gör många misstag",
+      "medium": "Medel – Balanserat spel",
+      "hard": "Svår – Utmanande motståndare",
+      "expert": "Expert – Nästan perfekt AI"
+    },
+    "mapType": "Banans typ",
+    "map": {
+      "classic": "Klassisk – Standard Pong",
+      "corners": "Hörnväggar – Mål endast i mitten",
+      "centerWall": "Mittvägg – Bollen går bara upp/ner"
+    },
+    "ballSpeed": "Bollhastighet",
+    "speed": {
+      "slow": "Långsam",
+      "medium": "Medel",
+      "fast": "Snabb",
+      "extreme": "Extrem"
+    },
+    "speedDescription": {
+      "easy": "Bra för nybörjare – Gott om reaktionstid",
+      "medium": "Balanserad – Bra för standardspelet",
+      "hard": "Utmanande – Testa dina reflexer",
+      "extreme": "Extrem – Endast för mästare!"
+    },
+    "powerUps": {
+      "title": "Power-ups",
+      "bigPaddle": "Stor racket",
+      "description": "Förstorar racket i 8 sekunder"
+    },
+    "reset": "Återställ standard",
+    "back": "Tillbaka",
+    "start": "Starta spelet"
+  },
+  "matchcard": {
+    "winner": "Vinnare",
+    "win": "{{name}} vinner"
+  },
+  "powerups": {
+    "bigPaddle": "Stor Racket"
+  },
+  "pongGame": {
+    "pressPToPause": "Tryck på 'P' för att pausa/fortsätta",
+    "clickToPlay": "Klicka för att spela",
+    "controlsWorkWhenFocused": "Spelkontroller fungerar endast när spelet är i fokus",
+    "gamePaused": "PAUSAT",
+    "pressPToResume": "Tryck på 'P' för att fortsätta",
+    "winnerMessage": "{{winner}} vinner!",
+    "restartMatch": "Starta om Match",
+    "returnToMainMenu": "Tillbaka till Huvudmenyn"
   }
 }


### PR DESCRIPTION
This pull request introduces internationalization (i18n) support for several components in the frontend, enabling dynamic translations for text displayed in the UI. 

### Updates to Component Texts:
* Replaced hardcoded strings in `GameCustomization.tsx` with translation keys for titles, labels, dropdown options, and button texts. 
* Updated `MatchCard.tsx` to use translation keys for winner announcement and button labels.
* Modified `PongGame.tsx` to use translations for game messages, power-up descriptions, and UI prompts. 

### Addition of Translation Files:
* Added new translation keys for English (`en.json`), Finnish (`fi.json`), and Swedish (`se.json`) to support multilingual text in the application. The keys cover game customization, match card, power-ups, and Pong game-related strings. [[1]]
