### PR TITLE
Custom names of tournaments supported

### DIFF
--- a/frontend/react/src/components/TournamentBuilder.tsx
+++ b/frontend/react/src/components/TournamentBuilder.tsx
@@ -15,6 +15,7 @@ const TournamentBuilder = () => {
   const [playerCount, setPlayerCount] = useState<number>(0);
   const [players, setPlayers] = useState<RegisteredPlayer[]>([]);
   const [registeredPlayers, setRegisteredPlayers] = useState<boolean[]>([]);
+  const [tournamentName, setTournamentName] = useState("");
   const { user } = useAuth();
   const { settings } = useGameSettings();
   const navigate = useNavigate();
@@ -98,11 +99,14 @@ const TournamentBuilder = () => {
       alert(t("tournament.errorAllPlayersRequired"));
       return;
     }
-
+    if (tournamentName === "") {
+      setTournamentName("Pong Tournament"); // default name if not provided
+    }
     try {
       // create a tournament
+
       const res = await api.post("/tournaments/create", {
-        name: "Pong Tournament",
+        name: tournamentName,
         size: playerCount,
         createdById: user?.id, // use user ID if logged in, otherwise 0
         status: "waiting",
@@ -188,7 +192,22 @@ const TournamentBuilder = () => {
             </p>
           </div>
         </div>
-
+        <div className="flex flex-col items-center mb-4">
+          <label
+            className="dark:text-white mb-2 font-bold"
+            htmlFor="nameTournament"
+          >
+            Tournament Name
+          </label>
+          <input
+            id="nameTournament"
+            placeholder="Pong Tournament"
+            type="text"
+            value={tournamentName}
+            className="dark:text-white mb-2 p-2 border rounded w-100"
+            onChange={(e) => setTournamentName(e.target.value)}
+          />
+        </div>
         <p className="dark:text-white">{t("tournament.enterUsernames")}</p>
         <div className="flex flex-col">
           {players.map((player, index) => (

--- a/frontend/react/src/components/TournamentBuilder.tsx
+++ b/frontend/react/src/components/TournamentBuilder.tsx
@@ -100,7 +100,7 @@ const TournamentBuilder = () => {
       return;
     }
     if (tournamentName === "") {
-      setTournamentName("Pong Tournament"); // default name if not provided
+      setTournamentName(t("tournament.placeholder")); // default name if not provided
     }
     try {
       // create a tournament
@@ -197,11 +197,11 @@ const TournamentBuilder = () => {
             className="dark:text-white mb-2 font-bold"
             htmlFor="nameTournament"
           >
-            Tournament Name
+            {t("tournament.placeholder")}
           </label>
           <input
             id="nameTournament"
-            placeholder="Pong Tournament"
+            placeholder={t("tournament.placeholder")}
             type="text"
             value={tournamentName}
             className="dark:text-white mb-2 p-2 border rounded w-100"

--- a/frontend/react/src/translations/en.json
+++ b/frontend/react/src/translations/en.json
@@ -199,6 +199,7 @@
     "errorAlreadyLoggedIn": "You're already logged in as {{username}}.",
     "errorAllPlayersRequired": "All players must enter a username.",
     "errorTournamentCreation": "Error creating tournament.",
-    "consoleCreating": "Let's make a tournament"
+    "consoleCreating": "Let's make a tournament",
+	"placeholder": "Pong Tournament" 
   }
 }

--- a/frontend/react/src/translations/fi.json
+++ b/frontend/react/src/translations/fi.json
@@ -200,6 +200,7 @@
     "errorAlreadyLoggedIn": "Olet jo kirjautunut nimellä {{username}}.",
     "errorAllPlayersRequired": "Kaikkien pelaajien on annettava käyttäjänimi.",
     "errorTournamentCreation": "Turnauksen luominen epäonnistui.",
-    "consoleCreating": "Luodaan turnaus"
+    "consoleCreating": "Luodaan turnaus",
+	"placeholder": "Pong Turnaus" 
   }
 }

--- a/frontend/react/src/translations/se.json
+++ b/frontend/react/src/translations/se.json
@@ -200,6 +200,7 @@
     "errorAlreadyLoggedIn": "Du är redan inloggad som {{username}}.",
     "errorAllPlayersRequired": "Alla spelare måste ange ett användarnamn.",
     "errorTournamentCreation": "Fel vid skapande av turnering.",
-    "consoleCreating": "Skapar turnering"
+    "consoleCreating": "Skapar turnering",
+	"placeholder": "Pong Turnering" 
   }
 }


### PR DESCRIPTION
The tournamentBuilder page now allows custom names of tournaments to be supported, and a default name is provided.

@staskine can you add new translations for the changes made here please before we approve this request? You can just push to this branch.