### PR TITLE
Now navigating before we await logout, no longer getting errors to console

### DIFF
--- a/frontend/react/src/components/NavigationHeader.tsx
+++ b/frontend/react/src/components/NavigationHeader.tsx
@@ -41,8 +41,8 @@ const NavigationHeader = ({
 
   const onLogoutClick = async () => {
     try {
-      await handleLogout();
       navigate("/");
+      await handleLogout();
     } catch (error) {
       console.error("Logout failed:", error);
     }


### PR DESCRIPTION
This resolves #129 by reversing the order of logout and navigate functions.