### PR TITLE
added translations to PongGameAI, PongGameWithRegistration and Round …

### DIFF
--- a/frontend/react/src/components/PongGameAI.tsx
+++ b/frontend/react/src/components/PongGameAI.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import PongGame from "./PongGame";
 import { useAuth } from "../auth/AuthProvider";
 import { useGameSettings } from "../contexts/GameSettingsContext";
+import { useTranslation } from "react-i18next";
 
 interface PongGameAIProps {
   onReturnToMenu?: () => void;
@@ -10,45 +11,46 @@ interface PongGameAIProps {
 const PongGameAI: React.FC<PongGameAIProps> = ({ onReturnToMenu }) => {
   const { user } = useAuth();
   const { settings } = useGameSettings();
+  const { t } = useTranslation();
 
   // Default player setup for AI game
   const player1 = user 
     ? { username: user.username, isGuest: false }
-    : { username: "Player", isGuest: true };
+    : { username: t("pongGameAI.defaultPlayer"), isGuest: true };
   
-  const player2 = { username: "AI Opponent", isGuest: true };
+  const player2 = { username: t("pongGameAI.aiOpponent"), isGuest: true };
 
   const getDifficultyDisplayName = () => {
     switch (settings.aiDifficulty) {
-      case 'easy': return 'Easy';
-      case 'medium': return 'Medium';
-      case 'hard': return 'Hard';
-      case 'expert': return 'Expert';
-      default: return 'Medium';
+      case 'easy': return t("pongGameAI.difficulty.easy");
+      case 'medium': return t("pongGameAI.difficulty.medium");
+      case 'hard': return t("pongGameAI.difficulty.hard");
+      case 'expert': return t("pongGameAI.difficulty.expert");
+      default: return t("pongGameAI.difficulty.medium");
     }
   };
 
   const getMapDisplayName = () => {
     switch (settings.mapType) {
-      case 'classic': return 'Classic';
-      case 'corners': return 'Corner Walls';
-      case 'center-wall': return 'Center Wall';
-      default: return 'Classic';
+      case 'classic': return t("pongGameAI.map.classic");
+      case 'corners': return t("pongGameAI.map.corners");
+      case 'center-wall': return t("pongGameAI.map.centerWall");
+      default: return t("pongGameAI.map.classic");
     }
   };
 
   return (
     <div className="flex flex-col items-center">
       <h2 className="text-2xl font-bold text-teal-700 dark:text-teal-300 mb-2">
-        Single Player vs AI
+        {t("pongGameAI.title")}
       </h2>
       
       <div className="mb-4 text-center dark:text-white space-y-1">
-        <p><strong>Map:</strong> {getMapDisplayName()}</p>
-        <p><strong>AI Difficulty:</strong> {getDifficultyDisplayName()}</p>
-        <p><strong>Score to Win:</strong> {settings.scoreToWin}</p>
-        <p><strong>Power-ups:</strong> {settings.powerUpsEnabled ? 'Enabled' : 'Disabled'}</p>
-        <p className="text-sm text-gray-600 dark:text-gray-400 mt-2">Use W/S keys to control your paddle</p>
+        <p><strong>{t("pongGameAI.labels.map")}:</strong> {getMapDisplayName()}</p>
+        <p><strong>{t("pongGameAI.labels.difficulty")}:</strong> {getDifficultyDisplayName()}</p>
+        <p><strong>{t("pongGameAI.labels.scoreToWin")}:</strong> {settings.scoreToWin}</p>
+        <p><strong>{t("pongGameAI.labels.powerUps")}:</strong> {settings.powerUpsEnabled ? t("pongGameAI.enabled") : t("pongGameAI.disabled")}</p>
+        <p className="text-sm text-gray-600 dark:text-gray-400 mt-2">{t("pongGameAI.instructions")}</p>
       </div>
       
       <PongGame 

--- a/frontend/react/src/components/PongGameWithRegistration.tsx
+++ b/frontend/react/src/components/PongGameWithRegistration.tsx
@@ -3,6 +3,7 @@ import PlayerRegistrationBox from "./PlayerRegistrationBox.tsx";
 import PongGame from "./PongGame";
 import { useAuth } from "../auth/AuthProvider";
 import { useGameSettings } from "../contexts/GameSettingsContext";
+import { useTranslation } from "react-i18next";
 
 const GAME_WIDTH = 500;
 const GAME_HEIGHT = 300;
@@ -11,9 +12,12 @@ interface PongGameWithRegistrationProps {
   onReturnToMenu?: () => void;
 }
 
-const PongGameWithRegistration: React.FC<PongGameWithRegistrationProps> = ({ onReturnToMenu }) => {
+const PongGameWithRegistration: React.FC<PongGameWithRegistrationProps> = ({
+  onReturnToMenu,
+}) => {
   const { status, user } = useAuth();
   const { settings } = useGameSettings();
+  const { t } = useTranslation();
   const [player1, setPlayer1] = useState<{
     username: string;
     isGuest: boolean;
@@ -32,10 +36,14 @@ const PongGameWithRegistration: React.FC<PongGameWithRegistrationProps> = ({ onR
 
   const getMapDisplayName = () => {
     switch (settings.mapType) {
-      case 'classic': return 'Classic';
-      case 'corners': return 'Corner Walls';
-      case 'center-wall': return 'Center Wall';
-      default: return 'Classic';
+      case "classic":
+        return t("pongGameWithRegistration.map.classic");
+      case "corners":
+        return t("pongGameWithRegistration.map.corners");
+      case "center-wall":
+        return t("pongGameWithRegistration.map.centerWall");
+      default:
+        return t("pongGameWithRegistration.map.classic");
     }
   };
 
@@ -47,35 +55,64 @@ const PongGameWithRegistration: React.FC<PongGameWithRegistrationProps> = ({ onR
       >
         <div className="flex-1 flex items-center justify-center border-r border-gray-700">
           {!player1 && status !== "authorized" && (
-            <PlayerRegistrationBox label="Player 1" onRegister={setPlayer1} playerId={1}/>
+            <PlayerRegistrationBox
+              label={t("pongGameWithRegistration.player1")}
+              onRegister={setPlayer1}
+              playerId={1}
+            />
           )}
           {player1 && <span className="text-white">{player1.username}</span>}
         </div>
         <div className="flex-1 flex items-center justify-center">
           {!player2 && (
-            <PlayerRegistrationBox label="Player 2" onRegister={setPlayer2} playerId={2}/>
+            <PlayerRegistrationBox
+              label={t("pongGameWithRegistration.player2")}
+              onRegister={setPlayer2}
+              playerId={2}
+            />
           )}
         </div>
       </div>
     );
   }
 
-  console.log("PongGameWithRegistration: Ready to render PongGame", { player1, player2, settings });
-  
+  console.log("PongGameWithRegistration: Ready to render PongGame", {
+    player1,
+    player2,
+    settings,
+  });
+
   return (
     <div className="flex flex-col items-center">
       <h2 className="text-2xl font-bold text-teal-700 dark:text-teal-300 mb-2">
-        2 Player Game
+        {t("pongGameWithRegistration.title")}
       </h2>
-      
+
       <div className="mb-4 text-center dark:text-white space-y-1">
-        <p><strong>Map:</strong> {getMapDisplayName()}</p>
-        <p><strong>Score to Win:</strong> {settings.scoreToWin}</p>
-        <p><strong>Power-ups:</strong> {settings.powerUpsEnabled ? 'Enabled' : 'Disabled'}</p>
-        <p className="text-sm text-gray-600 dark:text-gray-400 mt-2">Player 1: W/S keys | Player 2: Arrow Up/Down</p>
+        <p>
+          <strong>{t("pongGameWithRegistration.labels.map")}:</strong>
+          {getMapDisplayName()}
+        </p>
+        <p>
+          <strong>{t("pongGameWithRegistration.labels.scoreToWin")}:</strong>
+          {settings.scoreToWin}
+        </p>
+        <p>
+          <strong>{t("pongGameWithRegistration.labels.powerUps")}:</strong>
+          {settings.powerUpsEnabled
+            ? t("pongGameWithRegistration.enabled")
+            : t("pongGameWithRegistration.disabled")}
+        </p>
+        <p className="text-sm text-gray-600 dark:text-gray-400 mt-2">
+          {t("pongGameWithRegistration.instructions")}
+        </p>
       </div>
-      
-      <PongGame player1={player1} player2={player2} onReturnToMenu={onReturnToMenu} />
+
+      <PongGame
+        player1={player1}
+        player2={player2}
+        onReturnToMenu={onReturnToMenu}
+      />
     </div>
   );
 };

--- a/frontend/react/src/components/Round.tsx
+++ b/frontend/react/src/components/Round.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import MatchCard from "./MatchCard";
 import { Match, Player } from "../types/game";
+import { useTranslation } from "react-i18next";
 
 interface RoundProps {
   round: number;
@@ -9,10 +10,11 @@ interface RoundProps {
 }
 
 const Round: React.FC<RoundProps> = ({ round, matches, onPlay }) => {
+  const { t } = useTranslation();
   return (
     <div className="flex flex-col items-center gap-4">
       <h2 className="text-xl font-bold text-teal-700 dark:text-teal-300 mb-2">
-        Round {round}
+        {t("round.roundTitle", { round })}
       </h2>
       <div className="flex flex-row gap-8">
         {matches.map((match, i) => (

--- a/frontend/react/src/translations/en.json
+++ b/frontend/react/src/translations/en.json
@@ -200,7 +200,7 @@
     "errorAllPlayersRequired": "All players must enter a username.",
     "errorTournamentCreation": "Error creating tournament",
     "consoleCreating": "Let's make a tournament",
-	  "placeholder": "Pong Tournament" 
+    "placeholder": "Pong Tournament"
   },
   "gamecustomization": {
     "title": "Game Customization",
@@ -256,5 +256,51 @@
     "winnerMessage": "{{winner}} wins!",
     "restartMatch": "Restart Match",
     "returnToMainMenu": "Return to Main Menu"
+  },
+  "pongGameAI": {
+    "title": "Single Player vs AI",
+    "defaultPlayer": "Player",
+    "aiOpponent": "AI Opponent",
+    "labels": {
+      "map": "Map",
+      "difficulty": "AI Difficulty",
+      "scoreToWin": "Score to Win",
+      "powerUps": "Power-ups"
+    },
+    "difficulty": {
+      "easy": "Easy",
+      "medium": "Medium",
+      "hard": "Hard",
+      "expert": "Expert"
+    },
+    "map": {
+      "classic": "Classic",
+      "corners": "Corner Walls",
+      "centerWall": "Center Wall"
+    },
+    "enabled": "Enabled",
+    "disabled": "Disabled",
+    "instructions": "Use W/S keys to control your paddle"
+  },
+  "pongGameWithRegistration": {
+    "title": "2 Player Game",
+    "player1": "Player 1",
+    "player2": "Player 2",
+    "labels": {
+      "map": "Map",
+      "scoreToWin": "Score to Win",
+      "powerUps": "Power-ups"
+    },
+    "map": {
+      "classic": "Classic",
+      "corners": "Corner Walls",
+      "centerWall": "Center Wall"
+    },
+    "enabled": "Enabled",
+    "disabled": "Disabled",
+    "instructions": "Player 1: W/S keys | Player 2: Arrow Up/Down"
+  },
+  "round": {
+    "roundTitle": "Round {{round}}"
   }
 }

--- a/frontend/react/src/translations/fi.json
+++ b/frontend/react/src/translations/fi.json
@@ -201,7 +201,7 @@
     "errorAllPlayersRequired": "Kaikkien pelaajien on annettava käyttäjänimi.",
     "errorTournamentCreation": "Turnauksen luominen epäonnistui.",
     "consoleCreating": "Luodaan turnaus",
-	  "placeholder": "Pong Turnaus"
+    "placeholder": "Pong Turnaus"
   },
   "gamecustomization": {
     "title": "Pelin mukautus",
@@ -257,5 +257,51 @@
     "winnerMessage": "{{winner}} voitti!",
     "restartMatch": "Aloita Uudelleen",
     "returnToMainMenu": "Palaa Päävalikkoon"
+  },
+  "pongGameAI": {
+    "title": "Yksinpeli tekoälyä vastaan",
+    "defaultPlayer": "Pelaaja",
+    "aiOpponent": "Tekoälyvastustaja",
+    "labels": {
+      "map": "Kartta",
+      "difficulty": "Tekoälyn vaikeustaso",
+      "scoreToWin": "Voittoon vaadittavat pisteet",
+      "powerUps": "Tehosteet"
+    },
+    "difficulty": {
+      "easy": "Helppo",
+      "medium": "Keskitaso",
+      "hard": "Vaikea",
+      "expert": "Ekspertti"
+    },
+    "map": {
+      "classic": "Klassinen",
+      "corners": "Kulmaseinät",
+      "centerWall": "Keskiseinä"
+    },
+    "enabled": "Käytössä",
+    "disabled": "Ei käytössä",
+    "instructions": "Käytä W/S-näppäimiä ohjataksesi mailaa"
+  },
+  "pongGameWithRegistration": {
+    "title": "2 Pelaajan Peli",
+    "player1": "Pelaaja 1",
+    "player2": "Pelaaja 2",
+    "labels": {
+      "map": "Kartta",
+      "scoreToWin": "Voittopisteet",
+      "powerUps": "Tehosteet"
+    },
+    "map": {
+      "classic": "Klassinen",
+      "corners": "Kulmaseinät",
+      "centerWall": "Keskiseinä"
+    },
+    "enabled": "Käytössä",
+    "disabled": "Ei käytössä",
+    "instructions": "Pelaaja 1: W/S-näppäimet | Pelaaja 2: Nuoli ylös/alas"
+  },
+  "round": {
+    "roundTitle": "Kierros {{round}}"
   }
 }

--- a/frontend/react/src/translations/se.json
+++ b/frontend/react/src/translations/se.json
@@ -201,7 +201,7 @@
     "errorAllPlayersRequired": "Alla spelare måste ange ett användarnamn.",
     "errorTournamentCreation": "Fel vid skapande av turnering.",
     "consoleCreating": "Skapar turnering",
-	  "placeholder": "Pong Turnering" 
+    "placeholder": "Pong Turnering"
   },
   "gamecustomization": {
     "title": "Spelanpassning",
@@ -257,5 +257,51 @@
     "winnerMessage": "{{winner}} vinner!",
     "restartMatch": "Starta om Match",
     "returnToMainMenu": "Tillbaka till Huvudmenyn"
+  },
+  "pongGameAI": {
+    "title": "Enspelare mot AI",
+    "defaultPlayer": "Spelare",
+    "aiOpponent": "AI-motståndare",
+    "labels": {
+      "map": "Bana",
+      "difficulty": "AI-svårighetsgrad",
+      "scoreToWin": "Poäng för att vinna",
+      "powerUps": "Power-ups"
+    },
+    "difficulty": {
+      "easy": "Lätt",
+      "medium": "Medel",
+      "hard": "Svår",
+      "expert": "Expert"
+    },
+    "map": {
+      "classic": "Klassisk",
+      "corners": "Hörnväggar",
+      "centerWall": "Mittvägg"
+    },
+    "enabled": "Aktiverat",
+    "disabled": "Avaktiverat",
+    "instructions": "Använd W/S för att styra din racket"
+  },
+  "pongGameWithRegistration": {
+    "title": "2 Spelare",
+    "player1": "Spelare 1",
+    "player2": "Spelare 2",
+    "labels": {
+      "map": "Bana",
+      "scoreToWin": "Poäng för vinst",
+      "powerUps": "Power-ups"
+    },
+    "map": {
+      "classic": "Klassisk",
+      "corners": "Hörnväggar",
+      "centerWall": "Mittvägg"
+    },
+    "enabled": "Aktiverat",
+    "disabled": "Avaktiverat",
+    "instructions": "Spelare 1: W/S-tangenter | Spelare 2: Pil upp/ner"
+  },
+  "round": {
+    "roundTitle": "Omgång {{round}}"
   }
 }


### PR DESCRIPTION
This pull request introduces internationalization (i18n) support for several components in the React frontend, enabling dynamic translations based on user language preferences.

### Internationalization Integration:

* **Added `react-i18next` dependency and hooks to components**: Integrated the `useTranslation` hook into `PongGameAI`, `PongGameWithRegistration`, and `Round` components to dynamically fetch translations for UI text.

### Translation Key Usage:

* **Replaced hardcoded strings with translation keys**: Updated text elements in `PongGameAI` and `PongGameWithRegistration` components to use keys from the translation files, including labels for maps, difficulty levels, and instructions.
* **Dynamic round title**: Modified the `Round` component to display the round number dynamically using a translation key with parameters.

### Language Files Updates:

* **Added new translation keys**: Expanded the `en.json`, `fi.json`, and `se.json` files with keys for `pongGameAI`, `pongGameWithRegistration`, and `round` components, supporting English, Finnish, and Swedish translations.