### PR TITLE
Email password ghosts

### DIFF
--- a/frontend/react/src/components/PlayerRegistrationBox.tsx
+++ b/frontend/react/src/components/PlayerRegistrationBox.tsx
@@ -218,6 +218,7 @@ const PlayerRegistrationBox: React.FC<PlayerBoxProps> = ({
           placeholder={t("playerBox.usernamePlaceholder")}
           value={username}
           onChange={(e) => setUsername(e.target.value)}
+		  maxLength={20}
         />
         <input
           className="mb-2 p-2 border rounded w-48"
@@ -225,6 +226,7 @@ const PlayerRegistrationBox: React.FC<PlayerBoxProps> = ({
           placeholder={t("playerBox.passwordPlaceholder")}
           value={password}
           onChange={(e) => setPassword(e.target.value)}
+		  maxLength={42}
         />
         <button
           className="bg-teal-700 text-white px-4 py-2 rounded"

--- a/frontend/react/src/components/SettingsField.tsx
+++ b/frontend/react/src/components/SettingsField.tsx
@@ -99,6 +99,8 @@ const SettingsField: React.FC<FieldProps> = ({
       });
 
       setSuccess(t("settings.updateSuccess", { label }));
+	  setConfirmInput("");
+	  setCurrentPassword("");
       setError(null);
       setIsEditing(false);
       onUpdate?.(inputValue.trim());

--- a/frontend/react/src/components/TournamentBuilder.tsx
+++ b/frontend/react/src/components/TournamentBuilder.tsx
@@ -285,6 +285,7 @@ const TournamentBuilder = () => {
             value={tournamentName}
             className="dark:text-white mb-2 p-2 border rounded w-100"
             onChange={(e) => setTournamentName(e.target.value)}
+			maxLength={50}
           />
         </div>
         <p className="dark:text-white">{t("tournament.enterUsernames")}</p>


### PR DESCRIPTION
We are now resetting confirm email and current password fields to "" on successful updates to the SettingsField component so they are not persisting in the page state.

We've also added maximum lengths to the tournament name and player guest names.