### PR TITLE
Add customizable display name option for tournament players

### DIFF
--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -107,7 +107,7 @@ model Tournament {
   participants      TournamentParticipant[]
   winnerId          Int?
   winnerAlias       String?
-  status            String // "waiting" | "in_progress" | "finished"
+  status            String // "waiting" | "in_progress" | "completed"
 }
 
 model TournamentParticipant {
@@ -115,8 +115,8 @@ model TournamentParticipant {
   tournament   Tournament @relation(fields: [tournamentId], references: [id], onDelete: Cascade)
   tournamentId Int
   user         User?      @relation(fields: [userId], references: [id])
-  userId       Int?
-  alias        String? // for guests
+  userId       Int? // null for guests
+  alias        String? 
   joinedAt     DateTime   @default(now())
 }
 
@@ -129,7 +129,7 @@ model TournamentMatch {
 
   player1Id    Int?
   player1      User?   @relation("TM_Player1", fields: [player1Id], references: [id])
-  player1Alias String? // <– For guests
+  player1Alias String? 
 
   player2Id    Int?
   player2      User?   @relation("TM_Player2", fields: [player2Id], references: [id])
@@ -140,6 +140,4 @@ model TournamentMatch {
   winnerAlias String?
 
   status    String    @default("pending")
-  startedAt DateTime?
-  endedAt   DateTime?
 }

--- a/backend/srcs/routes/tournaments.js
+++ b/backend/srcs/routes/tournaments.js
@@ -292,7 +292,7 @@ async function isTournamentFinished(id, updatedMatch) {
     include: { tournamentMatches: true },
   });
   const pendingMatches = tournament.tournamentMatches.filter(match => match.status === "pending");
-  console.log("List of matches in isTfiniches::", tournament.tournamentMatches);
+  console.log("List of matches in isTournamentFinished:", tournament.tournamentMatches);
   if (pendingMatches.length === 0) {
     // If no pending matches, update tournament status to 'finished'
     await prisma.tournament.update({

--- a/backend/srcs/routes/tournaments.js
+++ b/backend/srcs/routes/tournaments.js
@@ -138,28 +138,6 @@ import { devOnly } from "../middleware/devOnly.js";
 
 //###############################################################
 
-  // Update tournament name
-  fastify.post(
-    "/tournaments/:id/update-name",
-    { schema: tournamentsSchemas.updateTournamentNameSchema },
-    async (req, reply) => {
-        const id = Number(req.params.id);
-        const { name } = req.body;
-        try {
-            const tournament = await prisma.tournament.update({
-                where: { id },
-                data: { name },
-            });
-            return reply.send(tournament);
-        } catch (error) {
-            // If no tournament with that ID exists, Prisma will throw
-            return reply.code(404).send({ message: "Tournament not found" });
-        }
-    }
-  )
-
-//###############################################################
-
   // Start a tournament
   fastify.post(
     "/tournaments/:id/start",

--- a/backend/srcs/routes/users.js
+++ b/backend/srcs/routes/users.js
@@ -627,7 +627,6 @@ export async function userRoutes(fastify, _options) {
 
   //####################################################################################################################################
 
-  // change isActivated = true once MFA is ready
   // is using queryRaw because Prisma 6 doesn't support the cleaner version I originally went for (requires Prisma < 5)
   fastify.get(
     "/users/search",
@@ -642,9 +641,8 @@ export async function userRoutes(fastify, _options) {
       const users = await prisma.$queryRaw`
 		   SELECT id, username
 		   FROM User
-		   WHERE isActivated = false
-		   	AND id != ${Number(excludeUserId) || -1}
-		    AND LOWER(username) LIKE ${query.toLowerCase() + "%"}
+		   WHERE id != ${Number(excludeUserId) || -1}
+		    AND username LIKE ${query + "%"}
 			LIMIT 20;
 		`;
 

--- a/backend/srcs/schemas/tournamentsSchemas.js
+++ b/backend/srcs/schemas/tournamentsSchemas.js
@@ -375,52 +375,8 @@ const deleteTournamentSchema = {
   },
 };
 
-//schema for updating tournament name
-const updateTournamentNameSchema = {
-  description: "Update a tournament's name",
-  tags: ["tournaments"],
-  params: {
-    type: "object",
-    properties: {
-      id: { type: "integer", minimum: 1 }
-    },
-    required: ["id"]
-  },
-  body: {
-    type: "object",
-    properties: {
-      name: { type: "string" }
-    },
-    required: ["name"],
-    additionalProperties: false
-  },
-  response: {
-    200: {
-      description: "The updated tournament object",
-      type: "object",
-      properties: {
-        id:           { type: "integer" },
-        name:         { type: "string" },
-        size:         { type: "integer" },
-        createdById:  { type: "integer" },
-        status:       { type: "string" }
-      },
-      required: ["id","name","size","createdById","status"]
-    },
-    404: {
-      description: "Tournament not found",
-      type: "object",
-      properties: {
-        message: { type: "string", example: "Tournament not found" }
-      },
-      required: ["message"]
-    }
-  }
-};
-
 export const tournamentsSchemas = {
   deleteTournamentSchema,
-  updateTournamentNameSchema,
   updateTournamentMatchSchema,
   startTournamentSchema,
   createTournamentSchema,

--- a/frontend/react/src/App.tsx
+++ b/frontend/react/src/App.tsx
@@ -18,8 +18,6 @@ import api from "./api/axios";
 import Mfa from "./pages/Mfa";
 import i18n from "./i18n";
 
-
-
 const App: React.FC = () => {
   const logout = async () => {
     try {
@@ -59,17 +57,18 @@ const App: React.FC = () => {
           element={<Navigate to="/stats" replace />}
         />
       </Routes>
-        {/* This is conditional rendering that will only show the show database button if vite is running in dev mode*/}
-      {import.meta.env.DEV ?
-	  <div className="flex justify-center my-4">
-        <button
-          className="border bg-teal-500 font-semibold hover:font-extrabold 
+      {/* This is conditional rendering that will only show the show database button if vite is running in dev mode*/}
+      {import.meta.env.DEV ? (
+        <div className="flex justify-center my-4">
+          <button
+            className="border bg-teal-500 font-semibold hover:font-extrabold 
 					  hover:underline uppercase text-white p-4 mx-4 rounded-2xl"
-          onClick={showDatabase}
-        >
-          show Database (for dev use only)
-        </button>
-      </div> : null}
+            onClick={showDatabase}
+          >
+            show Database (for dev use only)
+          </button>
+        </div>
+      ) : null}
     </GameSettingsProvider>
   );
 };

--- a/frontend/react/src/components/ChoosePlayMode.tsx
+++ b/frontend/react/src/components/ChoosePlayMode.tsx
@@ -12,6 +12,8 @@ const ChoosePlayMode = () => {
   const location = useLocation();
   const initialRenderRef = useRef(true);
   const prevKeyRef = useRef(location.key);
+  const headerRef = useRef<HTMLHeadingElement>(null);
+  const [headerWidth, setHeaderWidth] = useState<number | null>(null);
 
   // Handle home button click detection and game state reset
   useEffect(() => {
@@ -35,6 +37,12 @@ const ChoosePlayMode = () => {
     // Always update the previous key reference
     prevKeyRef.current = location.key;
   }, [location.key, location.pathname, selectedMode]);
+
+  useEffect(() => {
+    if (headerRef.current) {
+      setHeaderWidth(headerRef.current.offsetWidth);
+    }
+  }, []);
 
   useEffect(() => {
     if (selectedMode) {
@@ -124,20 +132,38 @@ const ChoosePlayMode = () => {
   return (
     <div>
       <div>
-        <h1 className="text-6xl text-center text-teal-800 dark:text-teal-300 m-3">
+        <h1
+          ref={headerRef}
+          className="text-6xl text-center text-teal-800 dark:text-teal-300 m-3"
+        >
           {t("CPM.choosePlayMode")}
         </h1>
-        <div className="flex">
-          <button className={buttonStyles} onClick={handleSinglePlayer}>
-            {t("CPM.singlevsAI")}
-          </button>
-          <button className={buttonStyles} onClick={handleTwoPlayer}>
-            {t("CPM.twoplayersingle")}
-          </button>
-          <button className={buttonStyles} onClick={handleCreateTournament}>
-            {t("CPM.createTournament")}
-          </button>
-        </div>
+
+        {headerWidth && (
+          <div
+            className="mx-auto mt-6 flex justify-between"
+            style={{ width: headerWidth }}
+          >
+            <button
+              className={`${buttonStyles} flex-1 text-xl mx-2`}
+              onClick={handleSinglePlayer}
+            >
+              {t("CPM.singlevsAI")}
+            </button>
+            <button
+              className={`${buttonStyles} flex-1 text-xl mx-2`}
+              onClick={handleTwoPlayer}
+            >
+              {t("CPM.twoplayersingle")}
+            </button>
+            <button
+              className={`${buttonStyles} flex-1 text-xl mx-2`}
+              onClick={handleCreateTournament}
+            >
+              {t("CPM.createTournament")}
+            </button>
+          </div>
+        )}
       </div>
     </div>
   );

--- a/frontend/react/src/components/ChoosePlayMode.tsx
+++ b/frontend/react/src/components/ChoosePlayMode.tsx
@@ -6,7 +6,15 @@ import TournamentBuilder from "./TournamentBuilder";
 import GameCustomization from "./GameCustomization";
 import { useTranslation } from "react-i18next";
 
-const ChoosePlayMode = () => {
+interface ChoosePlayModeProps {
+  onInteract?: () => void; // optional so it's reusable
+  onReturnToMenu?: () => void;
+}
+
+const ChoosePlayMode: React.FC<ChoosePlayModeProps> = ({
+  onInteract,
+  onReturnToMenu,
+}) => {
   const { t } = useTranslation();
   const [selectedMode, setSelectedMode] = useState<string | null>(null);
   const location = useLocation();
@@ -55,16 +63,19 @@ const ChoosePlayMode = () => {
   const handleSinglePlayer = () => {
     console.log("Selected Single Player mode");
     setSelectedMode("single-player-customize");
+    onInteract?.();
   };
 
   const handleTwoPlayer = () => {
     console.log("Selected Two Player mode");
     setSelectedMode("two-player-customize");
+    onInteract?.();
   };
 
   const handleCreateTournament = () => {
     console.log("Selected Tournament mode");
     setSelectedMode("tournament-customize");
+    onInteract?.();
   };
 
   // Added logging to debug transitions

--- a/frontend/react/src/components/ChoosePlayMode.tsx
+++ b/frontend/react/src/components/ChoosePlayMode.tsx
@@ -111,7 +111,7 @@ const ChoosePlayMode: React.FC<ChoosePlayModeProps> = ({
           console.log("Starting single player game");
           setSelectedMode("single-player");
         }}
-        onBack={() => setSelectedMode(null)}
+        onBack={() => { setSelectedMode(null); onReturnToMenu?.();}}
       />
     );
   } else if (selectedMode === "two-player-customize") {
@@ -122,7 +122,7 @@ const ChoosePlayMode: React.FC<ChoosePlayModeProps> = ({
           console.log("Starting two player game");
           setSelectedMode("two-player-single-game");
         }}
-        onBack={() => setSelectedMode(null)}
+        onBack={() => { setSelectedMode(null); onReturnToMenu?.();}}
       />
     );
   } else if (selectedMode === "tournament-customize") {
@@ -133,7 +133,7 @@ const ChoosePlayMode: React.FC<ChoosePlayModeProps> = ({
           console.log("Starting tournament creation");
           setSelectedMode("create-tournament");
         }}
-        onBack={() => setSelectedMode(null)}
+        onBack={() => { setSelectedMode(null); onReturnToMenu?.();}}
       />
     );
   } else if (selectedMode === "create-tournament") {

--- a/frontend/react/src/components/ChoosePlayMode.tsx
+++ b/frontend/react/src/components/ChoosePlayMode.tsx
@@ -142,33 +142,33 @@ const ChoosePlayMode: React.FC<ChoosePlayModeProps> = ({
   }
   return (
     <div>
-      <div>
+      <div className="flex flex-col items-center">
         <h1
           ref={headerRef}
-          className="text-6xl text-center text-teal-800 dark:text-teal-300 m-3"
+          className="text-5xl font-bold text-center text-teal-800 dark:text-teal-300 m-3"
         >
           {t("CPM.choosePlayMode")}
         </h1>
 
         {headerWidth && (
           <div
-            className="mx-auto mt-6 flex justify-between"
+            className="flex justify-center space-x-4 mt-4"
             style={{ width: headerWidth }}
           >
             <button
-              className={`${buttonStyles} flex-1 text-xl mx-2`}
+              className={`${buttonStyles} text-xl px-6 py-3 min-w-[180px]`}
               onClick={handleSinglePlayer}
             >
               {t("CPM.singlevsAI")}
             </button>
             <button
-              className={`${buttonStyles} flex-1 text-xl mx-2`}
+              className={`${buttonStyles} text-xl px-6 py-3 min-w-[180px]`}
               onClick={handleTwoPlayer}
             >
               {t("CPM.twoplayersingle")}
             </button>
             <button
-              className={`${buttonStyles} flex-1 text-xl mx-2`}
+              className={`${buttonStyles} text-xl px-6 py-3 min-w-[180px]`}
               onClick={handleCreateTournament}
             >
               {t("CPM.createTournament")}

--- a/frontend/react/src/components/CustomAliasField.tsx
+++ b/frontend/react/src/components/CustomAliasField.tsx
@@ -87,10 +87,14 @@ const CustomAliasField: React.FC<Props> = ({
   // dropdown display
   return (
     <div className="flex items-center justify-center space-x-2 text-lg">
-      <label className="font-bold text-teal-800 dark:text-teal-300 whitespace-nowrap">
+      <label htmlFor={`custom-alias-select-${index}`} className="font-bold text-teal-800 dark:text-teal-300 whitespace-nowrap">
         {t("tournament.playerLabel")} {index + 1}:
       </label>
-      <select
+      <select id={`custom-alias-select-${index}`}
+        aria-label={t("tournament.customAliasSelectAriaLabel", {
+        index: index + 1,
+        username,
+        })}
         className="text-teal-800 dark:text-teal-300 font-semibold bg-transparent text-lg"
         onChange={(e) => {
           if (e.target.value === "customize") {

--- a/frontend/react/src/components/CustomAliasField.tsx
+++ b/frontend/react/src/components/CustomAliasField.tsx
@@ -1,0 +1,98 @@
+import React, { useState } from "react";
+import { useTranslation } from "react-i18next";
+
+type Props = {
+  username: string;
+  index: number;
+  onUpdate: (newName: string) => void;
+  finalized: boolean;
+};
+
+const usernameRegex = /^[a-zA-Z0-9]+$/;
+
+const CustomAliasField: React.FC<Props> = ({
+  username,
+  index,
+  onUpdate,
+  finalized,
+}) => {
+  const { t } = useTranslation();
+  const [editing, setEditing] = useState(false);
+  const [customName, setCustomName] = useState(username);
+
+  if (finalized) {
+    return (
+      <div className="text-center text-teal-800 dark:text-teal-300 font-semibold">
+        {t("tournament.player", {
+          index: index + 1,
+          username,
+        })}
+      </div>
+    );
+  }
+
+  if (editing) {
+    return (
+      <div className="flex flex-col items-center">
+        <input
+          type="text"
+          value={customName}
+          onChange={(e) => setCustomName(e.target.value)}
+          className="bg-gray-50 border border-gray-300 text-gray-900 text-sm rounded-lg focus:ring-blue-500 focus:border-blue-500 block p-2.5 m-1 w-xs dark:bg-gray-700 dark:border-gray-600 dark:placeholder-gray-400 dark:text-white"
+          placeholder={t("tournament.customNamePlaceholder") || "Enter new display name"}
+          maxLength={20}
+        />
+        <div className="flex space-x-2 mt-2">
+          <button
+            className="bg-green-500 text-white px-4 py-1 rounded"
+            onClick={() => {
+              const newName = customName.trim();
+              if (
+                !newName ||
+                !usernameRegex.test(newName) ||
+                newName.length < 2 ||
+                newName.length > 20
+              ) {
+                alert(t("tournament.errorUsernameInvalid"));
+                return;
+              }
+
+              onUpdate(newName);
+              setEditing(false);
+            }}
+          >
+            {t("common.save")}
+          </button>
+          <button
+            className="bg-gray-400 text-white px-4 py-1 rounded"
+            onClick={() => setEditing(false)}
+          >
+            {t("common.cancel")}
+          </button>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="text-center">
+      <select
+        className="text-teal-800 dark:text-teal-300 font-semibold bg-transparent"
+        onChange={(e) => {
+          if (e.target.value === "customize") {
+            setEditing(true);
+            setCustomName(username);
+          }
+        }}
+        defaultValue=""
+      >
+        <option value="" disabled>
+          {username}
+        </option>
+        <option value="customize">{t("tournament.customizeDisplayName")}</option>
+      </select>
+    </div>
+  );
+};
+
+export default CustomAliasField;

--- a/frontend/react/src/components/CustomAliasField.tsx
+++ b/frontend/react/src/components/CustomAliasField.tsx
@@ -6,6 +6,7 @@ type Props = {
   index: number;
   onUpdate: (newName: string) => void;
   finalized: boolean;
+  isYou?: boolean;
 };
 
 const usernameRegex = /^[a-zA-Z0-9]+$/;
@@ -15,6 +16,7 @@ const CustomAliasField: React.FC<Props> = ({
   index,
   onUpdate,
   finalized,
+  isYou,
 }) => {
   const { t } = useTranslation();
   const [editing, setEditing] = useState(false);
@@ -22,62 +24,74 @@ const CustomAliasField: React.FC<Props> = ({
 
   if (finalized) {
     return (
-      <div className="text-center text-teal-800 dark:text-teal-300 font-semibold">
-        {t("tournament.player", {
-          index: index + 1,
-          username,
-        })}
+      <div className="flex items-center space-x-2 justify-center text-teal-800 dark:text-teal-300 font-semibold">
+        <span className="font-bold text-lg">
+        {isYou
+            ? t("tournament.playerYou", {
+                index: index + 1,
+                username,
+            })
+            : t("tournament.player", {
+                index: index + 1,
+                username,
+            })}
+        </span>
       </div>
     );
   }
 
   if (editing) {
     return (
-      <div className="flex flex-col items-center">
+      <div className="flex items-center justify-center space-x-2 text-lg">
+        <label className="font-bold text-teal-800 dark:text-teal-300 whitespace-nowrap">
+          {t("tournament.playerLabel")} {index + 1}:
+        </label>
         <input
           type="text"
           value={customName}
           onChange={(e) => setCustomName(e.target.value)}
-          className="bg-gray-50 border border-gray-300 text-gray-900 text-sm rounded-lg focus:ring-blue-500 focus:border-blue-500 block p-2.5 m-1 w-xs dark:bg-gray-700 dark:border-gray-600 dark:placeholder-gray-400 dark:text-white"
-          placeholder={t("tournament.customNamePlaceholder") || "Enter new display name"}
+          className="bg-gray-50 border border-gray-300 text-gray-900 text-sm rounded-lg focus:ring-blue-500 focus:border-blue-500 p-2 w-48 dark:bg-gray-700 dark:border-gray-600 dark:text-white"
+          placeholder={t("tournament.playerLabel") || "Enter new display name"}
           maxLength={20}
         />
-        <div className="flex space-x-2 mt-2">
-          <button
-            className="bg-green-500 text-white px-4 py-1 rounded"
-            onClick={() => {
-              const newName = customName.trim();
-              if (
-                !newName ||
-                !usernameRegex.test(newName) ||
-                newName.length < 2 ||
-                newName.length > 20
-              ) {
-                alert(t("tournament.errorUsernameInvalid"));
-                return;
-              }
+        <button
+          className="bg-green-500 text-white px-4 py-1 rounded"
+          onClick={() => {
+            const newName = customName.trim();
+            if (
+              !newName ||
+              !usernameRegex.test(newName) ||
+              newName.length < 2 ||
+              newName.length > 20
+            ) {
+              alert(t("tournament.errorUsernameInvalid"));
+              return;
+            }
 
-              onUpdate(newName);
-              setEditing(false);
-            }}
-          >
-            {t("common.save")}
-          </button>
-          <button
-            className="bg-gray-400 text-white px-4 py-1 rounded"
-            onClick={() => setEditing(false)}
-          >
-            {t("common.cancel")}
-          </button>
-        </div>
+            onUpdate(newName);
+            setEditing(false);
+          }}
+        >
+          {t("settings.save")}
+        </button>
+        <button
+          className="bg-gray-400 text-white px-4 py-1 rounded"
+          onClick={() => setEditing(false)}
+        >
+          {t("settings.cancel")}
+        </button>
       </div>
     );
   }
 
+  // dropdown display
   return (
-    <div className="text-center">
+    <div className="flex items-center justify-center space-x-2 text-lg">
+      <label className="font-bold text-teal-800 dark:text-teal-300 whitespace-nowrap">
+        {t("tournament.playerLabel")} {index + 1}:
+      </label>
       <select
-        className="text-teal-800 dark:text-teal-300 font-semibold bg-transparent"
+        className="text-teal-800 dark:text-teal-300 font-semibold bg-transparent text-lg"
         onChange={(e) => {
           if (e.target.value === "customize") {
             setEditing(true);

--- a/frontend/react/src/components/MatchCard.tsx
+++ b/frontend/react/src/components/MatchCard.tsx
@@ -37,12 +37,12 @@ const MatchCard: React.FC<MatchCardProps> = ({ match, onLaunch }) => {
           </button>
         </>
       ) : (
-        <div className="flex justify-between items-center">
-          <div>
+        <div className="flex flex-col items-center">
+          <div className="mb-1">
             <span className="font-semibold">{player1.name}</span> vs{" "}
             <span className="font-semibold">{player2.name}</span>
           </div>
-          <div className="text-green-600 font-semibold">
+          <div className="text-green-600 font-bold text-2xl">
             {t("matchcard.winner")}: {winnerDisplay}
           </div>
         </div>

--- a/frontend/react/src/components/TournamentBuilder.tsx
+++ b/frontend/react/src/components/TournamentBuilder.tsx
@@ -39,11 +39,11 @@ const TournamentBuilder = () => {
 
   useEffect(() => {
     if (playerCount > 0) {
-      const initialPlayers: RegisteredPlayer[] = Array(playerCount).fill({
-        username: "",
-        isGuest: true,
-        userId: null,
-      });
+      const initialPlayers: RegisteredPlayer[] = Array.from({ length: playerCount }, () => ({
+    username: "",
+    isGuest: true,
+    userId: null,
+  }));
 
       setPlayers(initialPlayers);
       setRegisteredPlayers(initialPlayers.map((p) => !!p.username)); // if username is filled, mark as registered
@@ -56,7 +56,7 @@ const TournamentBuilder = () => {
     if (user && players.length > 0) {
       const updatedPlayers = [...players];
       const alreadyInSlot = updatedPlayers.some(
-        (p) => !p.isGuest && p.username === user.username
+        (p) => !p.isGuest && p.userId === user.id
       );
       if (alreadyInSlot) return; // prevent duplicates
 
@@ -67,7 +67,7 @@ const TournamentBuilder = () => {
         updatedPlayers[firstGuestIndex] = {
           username: user.username,
           isGuest: false,
-          userId: user.id,
+          userId: Number(user.id),
         };
         setPlayers(updatedPlayers); // Only update state here
 
@@ -259,6 +259,55 @@ const TournamentBuilder = () => {
         <div className="flex flex-col">
           {players.map((player, index) => (
             <div key={index} className="my-2">
+              {registeredPlayers[index] ? (
+                <CustomAliasField
+                    index={index}
+                    username={player.username}
+                    finalized={finalizedCustomName.has(index)}
+                    isYou={!!user && player.username === user.username && !player.isGuest}
+                    onUpdate={(newName) => {
+                    const duplicate = players.some(
+                        (p, i) => i !== index && p.username === newName
+                    );
+                    if (duplicate) {
+                        alert(t("tournament.errorUsernameTaken", { username: newName }));
+                        return;
+                    }
+
+                    const updated = [...players];
+                    updated[index] = {
+                        ...updated[index],
+                        username: newName,
+                    };
+                    setPlayers(updated);
+                    setFinalizedCustomName((prev) => new Set(prev).add(index));
+                    }}
+                />
+              ) : index === currentRegistrationIndex ? (
+                <PlayerRegistrationBox
+                  label={`${t("tournament.playerLabel")} ${index + 1}`}
+                  onRegister={(p) => updatePlayer(index, p)}
+                  playerId={index + 1}
+                />
+              ) : null}
+            </div>
+          ))}
+          {registeredPlayers.every(Boolean) && (
+            <button className={buttonStyles} onClick={handleCreateTournament}>
+              {t("tournament.createButton")}
+            </button>
+          )}
+        </div>
+      </div>
+    );
+};
+export default TournamentBuilder;
+
+
+{/* <p className="dark:text-white">{t("tournament.enterUsernames")}</p>
+        <div className="flex flex-col">
+          {players.map((player, index) => (
+            <div key={index} className="my-2">
               {user && player.username === user.username && !player.isGuest ? (
                 <div className="text-center text-teal-800 dark:text-teal-300 font-bold">
                   {t("tournament.playerYou", {
@@ -304,7 +353,4 @@ const TournamentBuilder = () => {
             </button>
           )}
         </div>
-      </div>
-    );
-};
-export default TournamentBuilder;
+      </div> */}

--- a/frontend/react/src/components/TournamentBuilder.tsx
+++ b/frontend/react/src/components/TournamentBuilder.tsx
@@ -4,6 +4,7 @@ import { useNavigate } from "react-router-dom";
 import PlayerRegistrationBox from "./PlayerRegistrationBox";
 import api from "../api/axios";
 import { useGameSettings } from "../contexts/GameSettingsContext";
+import CustomAliasField from "./CustomAliasField";
 import { useTranslation } from "react-i18next";
 
 type RegisteredPlayer = {
@@ -29,6 +30,7 @@ const TournamentBuilder = () => {
   const [players, setPlayers] = useState<RegisteredPlayer[]>([]);
   const [registeredPlayers, setRegisteredPlayers] = useState<boolean[]>([]);
   const [currentRegistrationIndex, setCurrentRegistrationIndex] = useState(0);
+  const [finalizedCustomName, setFinalizedCustomName] = useState<Set<number>>(new Set());
   const [tournamentName, setTournamentName] = useState("");
   const { user } = useAuth();
   const { settings } = useGameSettings();
@@ -265,12 +267,28 @@ const TournamentBuilder = () => {
                   })}
                 </div>
               ) : registeredPlayers[index] ? (
-                <div className="text-center text-teal-800 dark:text-teal-300 font-semibold">
-                  {t("tournament.player", {
-                    index: index + 1,
-                    username: player.username,
-                  })}
-                </div>
+                <CustomAliasField
+                    index={index}
+                    username={player.username}
+                    finalized={finalizedCustomName.has(index)}
+                    onUpdate={(newName) => {
+                    const duplicate = players.some(
+                        (p, i) => i !== index && p.username === newName
+                    );
+                    if (duplicate) {
+                        alert(t("tournament.errorUsernameTaken", { username: newName }));
+                        return;
+                    }
+
+                    const updated = [...players];
+                    updated[index] = {
+                        ...updated[index],
+                        username: newName,
+                    };
+                    setPlayers(updated);
+                    setFinalizedCustomName((prev) => new Set(prev).add(index));
+                    }}
+                />
               ) : index === currentRegistrationIndex ? (
                 <PlayerRegistrationBox
                   label={`${t("tournament.playerLabel")} ${index + 1}`}

--- a/frontend/react/src/pages/Home.tsx
+++ b/frontend/react/src/pages/Home.tsx
@@ -1,4 +1,5 @@
-import React, { useEffect } from "react";
+import React, { useEffect, useState, useRef } from "react";
+import { useLocation } from "react-router-dom";
 import { Link } from "react-router-dom";
 import { AuthContextType } from "../auth/AuthProvider";
 import { useTranslation } from "react-i18next";
@@ -12,6 +13,9 @@ interface HomeProps {
 
 const Home: React.FC<HomeProps> = ({ status, user }) => {
   const { t } = useTranslation();
+  const location = useLocation();
+  const [inMenu, setInMenu] = useState(true);
+  const locationKeyRef = useRef(location.key);
 
   useEffect(() => {
     if (status !== "authorized") {
@@ -19,35 +23,57 @@ const Home: React.FC<HomeProps> = ({ status, user }) => {
     }
   }, [status, user]);
 
+  useEffect(() => {
+    // Reset to menu mode every time we navigate to "/"
+    if (location.pathname === "/" && location.key !== locationKeyRef.current) {
+      console.log("Navigated to / with a new location.key — resetting inMenu");
+      setInMenu(true);
+    }
+    locationKeyRef.current = location.key;
+  }, [location.key, location.pathname]);
+
   return (
     <div className="text-center max-w-2xl dark:bg-black bg-white mx-auto rounded-lg my-5">
       <div className="flex justify-center">
-        <ChoosePlayMode />
+        <ChoosePlayMode
+          onInteract={() => {
+            console.log("User interacted — hiding welcome");
+            setInMenu(false);
+          }}
+          onReturnToMenu={() => {
+            console.log("User returned to menu — showing welcome");
+            setInMenu(true);
+          }}
+        />
       </div>
-      <h1 className="text-6xl text-center text-teal-800 dark:text-teal-300 m-3">
-        {t("home.welcome")}
-      </h1>
+      {inMenu && (
+        <>
+          <h1 className="text-6xl text-center text-teal-800 dark:text-teal-300 m-3">
+            {t("home.welcome")}
+          </h1>
 
-      {status === "loading" ? (
-        <p>{t("home.checkingSession")}</p>
-      ) : status === "authorized" && user ? (
-        <>
-          <p className="dark:text-white pb-10">
-            {t("home.hello")}, {user.username}
-          </p>
-        </>
-      ) : (
-        <>
-          <p className="dark:text-white text-center">{t("home.pleaseLogin")}</p>
-          <p className="dark:text-white text-center font-bold p-5">
-            {t("home.noAccount")}{" "}
-            <Link
-              className="text-amber-900 dark:text-amber-300 font:bold hover:font-extrabold"
-              to="/register"
-            >
-              {t("home.register")}
-            </Link>
-          </p>
+          {status === "loading" ? (
+            <p>{t("home.checkingSession")}</p>
+          ) : status === "authorized" && user ? (
+            <p className="dark:text-white pb-10">
+              {t("home.hello")}, {user.username}
+            </p>
+          ) : (
+            <>
+              <p className="dark:text-white text-center">
+                {t("home.pleaseLogin")}
+              </p>
+              <p className="dark:text-white text-center font-bold p-5">
+                {t("home.noAccount")}{" "}
+                <Link
+                  className="text-amber-900 dark:text-amber-300 font:bold hover:font-extrabold"
+                  to="/register"
+                >
+                  {t("home.register")}
+                </Link>
+              </p>
+            </>
+          )}
         </>
       )}
     </div>

--- a/frontend/react/src/pages/Home.tsx
+++ b/frontend/react/src/pages/Home.tsx
@@ -33,49 +33,55 @@ const Home: React.FC<HomeProps> = ({ status, user }) => {
   }, [location.key, location.pathname]);
 
   return (
-    <div className="text-center max-w-2xl dark:bg-black bg-white mx-auto rounded-lg my-5">
-      <div className="flex justify-center">
-        <ChoosePlayMode
-          onInteract={() => {
-            console.log("User interacted — hiding welcome");
-            setInMenu(false);
-          }}
-          onReturnToMenu={() => {
-            console.log("User returned to menu — showing welcome");
-            setInMenu(true);
-          }}
-        />
-      </div>
+    <div className="text-center max-w-2xl dark:bg-black bg-white mx-auto rounded-lg my-5 flex flex-col justify-center items-center min-h-[400px] px-4 py-6">
       {inMenu && (
         <>
-          <h1 className="text-6xl text-center text-teal-800 dark:text-teal-300 m-3">
-            {t("home.welcome")}
-          </h1>
-
           {status === "loading" ? (
             <p>{t("home.checkingSession")}</p>
           ) : status === "authorized" && user ? (
-            <p className="dark:text-white pb-10">
-              {t("home.hello")}, {user.username}
-            </p>
+            <>
+                <h1 className="text-6xl text-center text-teal-800 dark:text-teal-300 m-3">
+                    {t("home.welcome")}
+                </h1>
+                <p className="dark:text-white pb-10">
+                ✨{" "}{t("home.hello")}, {user.username}{" "}✨
+                </p>
+            </>
           ) : (
             <>
-              <p className="dark:text-white text-center">
-                {t("home.pleaseLogin")}
-              </p>
+              <section className="max-w-3xl mx-auto text-center pt-8 px-6">
+                <h1 className="text-4xl font-bold mb-4 text-teal-900 dark:text-teal-300">
+                  {t("pongIntro.title")}
+                </h1>
+                <p className="text-lg mb-6 text-gray-800 dark:text-gray-200">{t("pongIntro.paragraph1")}</p>
+                <p className="text-lg mb-6 text-gray-800 dark:text-gray-200">{t("pongIntro.paragraph2")}</p>
+                <p className="text-xl font-semibold text-red-900 dark:text-red-500">
+                  {t("pongIntro.conclusion")}
+                </p>
+              </section>
               <p className="dark:text-white text-center font-bold p-5">
-                {t("home.noAccount")}{" "}
+                🏓 {t("home.noAccount")}{" "}
                 <Link
                   className="text-amber-900 dark:text-amber-300 font:bold hover:font-extrabold"
                   to="/register"
                 >
-                  {t("home.register")}
+                  {t("home.register")} 🏓
                 </Link>
               </p>
             </>
           )}
         </>
       )}
+      <ChoosePlayMode
+        onInteract={() => {
+          console.log("User interacted — hiding welcome");
+          setInMenu(false);
+        }}
+        onReturnToMenu={() => {
+          console.log("User returned to menu — showing welcome");
+          setInMenu(true);
+        }}
+      />
     </div>
   );
 };

--- a/frontend/react/src/pages/TournamentPage.tsx
+++ b/frontend/react/src/pages/TournamentPage.tsx
@@ -103,7 +103,7 @@ const TournamentPage = () => {
     if (finalStandings.length === 0) return;
 
     const timer = setTimeout(async () => {
-      //alert(t("tournament.overMessage")); // e.g. "Tournament over! Redirecting home."
+      alert(t("tournament.overMessage")); // e.g. "Tournament over! Redirecting home."
       try {
         await api.delete(
           `/tournaments/${tournamentId}/${encodeURIComponent(tournamentName)}`
@@ -112,7 +112,7 @@ const TournamentPage = () => {
         console.error("Failed to delete tournament:", err);
       }
       navigate("/", { replace: true });
-    }, 20_000); // ← 20 seconds
+    }, 15_000); // ← 15 seconds
 
     return () => clearTimeout(timer);
   }, [finalStandings, tournamentId, tournamentName, navigate, /*t*/]);

--- a/frontend/react/src/translations/en.json
+++ b/frontend/react/src/translations/en.json
@@ -217,7 +217,8 @@
     "consoleCreating": "Let's make a tournament",
     "placeholder": "Pong Tournament",
     "nameYourTournament": "Name your tournament",
-    "customizeDisplayName": "Customize display name"
+    "customizeDisplayName": "Customize display name",
+    "overMessage": "Tournament over, redirecting..."
   },
   "gamecustomization": {
     "title": "Game Customization",

--- a/frontend/react/src/translations/en.json
+++ b/frontend/react/src/translations/en.json
@@ -216,7 +216,8 @@
     "errorTournamentCreation": "Error creating tournament",
     "consoleCreating": "Let's make a tournament",
     "placeholder": "Pong Tournament",
-    "nameYourTournament": "Name your tournament"
+    "nameYourTournament": "Name your tournament",
+    "customizeDisplayName": "Customize display name"
   },
   "gamecustomization": {
     "title": "Game Customization",

--- a/frontend/react/src/translations/en.json
+++ b/frontend/react/src/translations/en.json
@@ -181,14 +181,14 @@
   },
   "CPM": {
     "choosePlayMode": "Choose Play Mode",
-    "singlevsAI": "Single Player vs AI",
-    "twoplayersingle": "2 Player Single Game",
-    "createTournament": "Create Tournament"
+    "singlevsAI": "1 Player",
+    "twoplayersingle": "2 Player",
+    "createTournament": "Tournament"
   },
   "tournament": {
     "createTitle": "Create Tournament",
-    "4playerMode": "4 Player Mode",
-    "8playerMode": "8 Player Mode",
+    "4playerMode": "4 Players",
+    "8playerMode": "8 Players",
     "gameSettings": "Game Settings",
     "map": "Map",
     "mapClassic": "Classic",

--- a/frontend/react/src/translations/en.json
+++ b/frontend/react/src/translations/en.json
@@ -198,7 +198,7 @@
     "powerUps": "Power-ups",
     "enabled": "Enabled",
     "disabled": "Disabled",
-    "enterUsernames": "Enter the usernames or register as a guest.",
+    "enterUsernames": "Login or register as a guest.",
     "playerYou": "Player {{index}} (You): {{username}}",
     "player": "Player {{index}}: {{username}}",
     "playerLabel": "Player",
@@ -209,7 +209,8 @@
     "errorAllPlayersRequired": "All players must enter a username.",
     "errorTournamentCreation": "Error creating tournament",
     "consoleCreating": "Let's make a tournament",
-    "placeholder": "Pong Tournament"
+    "placeholder": "Pong Tournament",
+    "nameYourTournament": "Name your tournament"
   },
   "gamecustomization": {
     "title": "Game Customization",

--- a/frontend/react/src/translations/en.json
+++ b/frontend/react/src/translations/en.json
@@ -3,9 +3,15 @@
     "welcome": "Welcome!",
     "checkingSession": "Checking session...",
     "hello": "Hello",
-    "pleaseLogin": "Please log in to access exclusive Pong content and connect with other registered players!",
+    "pleaseLogin": "Please log in to keep track of your stats, connect with other registered players and play in other languages!",
     "noAccount": "No account?",
     "register": "Register"
+  },
+  "pongIntro": {
+    "title": "🎮 Welcome to Pong — The Game That Started It All! 🕹️",
+    "paragraph1": "Step back in time to 1972, when two paddles, one bouncing ball, and a black-and-white screen changed gaming forever. Pong isn't just a game — it's the spark that lit the video game revolution. Simple, addictive, and endlessly competitive, this digital table tennis classic brings back the golden age of arcade fun.",
+    "paragraph2": "Whether you're here for nostalgia or discovering it for the first time, Pong proves that great gameplay never gets old. So grab your paddle, challenge a friend, and see who can keep the rally going the longest.",
+    "conclusion": "Let the original battle of reflexes begin! 🏓"
   },
   "stats": {
     "loading": "Loading...",
@@ -267,7 +273,8 @@
     "pressPToResume": "Press 'P' to resume",
     "winnerMessage": "{{winner}} wins!",
     "restartMatch": "Restart Match",
-    "returnToMainMenu": "Return to Main Menu"
+    "returnToMainMenu": "Return to Main Menu",
+    "returnToBracket": "Continue Tournament"
   },
   "pongGameAI": {
     "title": "Single Player vs AI",

--- a/frontend/react/src/translations/fi.json
+++ b/frontend/react/src/translations/fi.json
@@ -3,7 +3,7 @@
     "welcome": "Tervetuloa!",
     "checkingSession": "Tarkistetaan istuntoa...",
     "hello": "Hei",
-    "pleaseLogin": "Kirjaudu sisään päästäksesi eksklusiiviseen Pong-sisältöön ja yhdistääksesi muihin rekisteröityihin pelaajiin!",
+    "pleaseLogin": "Kirjaudu sisään seurataksesi tuloksiasi ja vittuillaksesi muille pelaajille",
     "noAccount": "Ei tiliä?",
     "register": "Rekisteröidy"
   },
@@ -268,7 +268,8 @@
     "pressPToResume": "Paina 'P' jatkaaksesi",
     "winnerMessage": "{{winner}} voitti!",
     "restartMatch": "Aloita Uudelleen",
-    "returnToMainMenu": "Palaa Päävalikkoon"
+    "returnToMainMenu": "Palaa Päävalikkoon",
+    "returnToBracket": "Jatka Turnausta"
   },
   "pongGameAI": {
     "title": "Yksinpeli tekoälyä vastaan",

--- a/frontend/react/src/translations/fi.json
+++ b/frontend/react/src/translations/fi.json
@@ -199,7 +199,7 @@
     "powerUps": "Tehosteet",
     "enabled": "Käytössä",
     "disabled": "Ei käytössä",
-    "enterUsernames": "Anna käyttäjänimet tai rekisteröidy vieraana.",
+    "enterUsernames": "Kirjaudu sisään tai rekisteröidy vieraana.",
     "playerYou": "Pelaaja {{index}} (Sinä): {{username}}",
     "player": "Pelaaja {{index}}: {{username}}",
     "playerLabel": "Pelaaja",
@@ -210,7 +210,8 @@
     "errorAllPlayersRequired": "Kaikkien pelaajien on annettava käyttäjänimi.",
     "errorTournamentCreation": "Turnauksen luominen epäonnistui.",
     "consoleCreating": "Luodaan turnaus",
-    "placeholder": "Pong Turnaus"
+    "placeholder": "Pong Turnaus",
+    "nameYourTournament": "Nimeä turnaus"
   },
   "gamecustomization": {
     "title": "Pelin mukautus",

--- a/frontend/react/src/translations/fi.json
+++ b/frontend/react/src/translations/fi.json
@@ -212,7 +212,8 @@
     "consoleCreating": "Luodaan turnaus",
     "placeholder": "Pong Turnaus",
     "nameYourTournament": "Nimeä turnaus",
-    "customizeDisplayName": "Vaihda näyttönimi"
+    "customizeDisplayName": "Vaihda näyttönimi",
+    "overMessage": "Turnaus päättyi, uudelleenohjataan..."
   },
   "gamecustomization": {
     "title": "Pelin mukautus",

--- a/frontend/react/src/translations/fi.json
+++ b/frontend/react/src/translations/fi.json
@@ -211,7 +211,8 @@
     "errorTournamentCreation": "Turnauksen luominen epäonnistui.",
     "consoleCreating": "Luodaan turnaus",
     "placeholder": "Pong Turnaus",
-    "nameYourTournament": "Nimeä turnaus"
+    "nameYourTournament": "Nimeä turnaus",
+    "customizeDisplayName": "Vaihda näyttönimi"
   },
   "gamecustomization": {
     "title": "Pelin mukautus",

--- a/frontend/react/src/translations/se.json
+++ b/frontend/react/src/translations/se.json
@@ -211,7 +211,8 @@
     "errorTournamentCreation": "Fel vid skapande av turnering.",
     "consoleCreating": "Skapar turnering",
     "placeholder": "Pong Turnering",
-    "nameYourTournament": "Namnge din turnering"
+    "nameYourTournament": "Namnge din turnering",
+    "customizeDisplayName": "Anpassa visningsnamn"
   },
   "gamecustomization": {
     "title": "Spelanpassning",

--- a/frontend/react/src/translations/se.json
+++ b/frontend/react/src/translations/se.json
@@ -212,7 +212,8 @@
     "consoleCreating": "Skapar turnering",
     "placeholder": "Pong Turnering",
     "nameYourTournament": "Namnge din turnering",
-    "customizeDisplayName": "Anpassa visningsnamn"
+    "customizeDisplayName": "Anpassa visningsnamn",
+    "overMessage": "Turneringen är över, omdirigerar..."
   },
   "gamecustomization": {
     "title": "Spelanpassning",

--- a/frontend/react/src/translations/se.json
+++ b/frontend/react/src/translations/se.json
@@ -199,7 +199,7 @@
     "powerUps": "Power-ups",
     "enabled": "Aktiverat",
     "disabled": "Avaktiverat",
-    "enterUsernames": "Ange användarnamn eller registrera dig som gäst.",
+    "enterUsernames": "Logga in eller registrera dig som gäst.",
     "playerYou": "Spelare {{index}} (Du): {{username}}",
     "player": "Spelare {{index}}: {{username}}",
     "playerLabel": "Spelare",
@@ -210,7 +210,8 @@
     "errorAllPlayersRequired": "Alla spelare måste ange ett användarnamn.",
     "errorTournamentCreation": "Fel vid skapande av turnering.",
     "consoleCreating": "Skapar turnering",
-    "placeholder": "Pong Turnering"
+    "placeholder": "Pong Turnering",
+    "nameYourTournament": "Namnge din turnering"
   },
   "gamecustomization": {
     "title": "Spelanpassning",

--- a/frontend/react/src/translations/se.json
+++ b/frontend/react/src/translations/se.json
@@ -3,7 +3,7 @@
     "welcome": "Välkommen!",
     "checkingSession": "Kontrollerar session...",
     "hello": "Hej",
-    "pleaseLogin": "Vänligen logga in för att få tillgång till exklusivt Pong-innehåll och för att kunna koppla upp dig med andra registrerade spelare!",
+    "pleaseLogin": "Logga in för att hålla koll på din statistik och för att kunna ansluta med andra registrerade spelare!",
     "noAccount": "Inget konto?",
     "register": "Registrera dig"
   },
@@ -268,7 +268,8 @@
     "pressPToResume": "Tryck på 'P' för att fortsätta",
     "winnerMessage": "{{winner}} vinner!",
     "restartMatch": "Starta om Match",
-    "returnToMainMenu": "Tillbaka till Huvudmenyn"
+    "returnToMainMenu": "Tillbaka till Huvudmenyn",
+    "returnToBracket": "Fortsätta"
   },
   "pongGameAI": {
     "title": "Enspelare mot AI",


### PR DESCRIPTION
This pull request introduces various changes across the backend and frontend to improve functionality, clean up code, and enhance user experience. The most notable updates include schema modifications for better data consistency, removal of unused code, and UI enhancements for tournament-related features.

* Updated the `status` field in the `Tournament` model to use `"completed"` instead of `"finished"`.
* Removed `startedAt` and `endedAt` fields from the `TournamentMatch` model, simplifying match tracking.
* Removed the `/tournaments/:id/update-name` endpoint and its associated schema, as it is no longer needed.
* Simplified the `/users/search` query to exclude the `isActivated` condition, streamlining user search functionality.

* Added a new `CustomAliasField` component to allow users to customize their display names in tournaments.
* Enhanced the `ChoosePlayMode` component with new props (`onInteract`, `onReturnToMenu`) and header width adjustments for better flexibility and responsiveness.

* Updated the `MatchCard` component to improve the visual layout and emphasize the winner's name with bold, larger text.
* Refined conditional rendering in `App.tsx` to improve readability and maintainability.

* Introduced validation for player usernames and added logic to manage custom aliases for tournament participants.
* Removed redundant logic for creating tournaments on component mount, streamlining the setup process.

* Redesigned Home page to introduce users about what the site is about
* Added missing alert to `Victory` component to alert user about the redirect
* Have `TournamentBuilder` show one player registration slot at a time and hide "Create Tournament" button until all registration slots are filled
* Added drop down menu option for display name customization

Closes #155 #156 #157 #153