### PR TITLE
added small security upgrades

### DIFF
--- a/backend/srcs/APItest/testAPI.http
+++ b/backend/srcs/APItest/testAPI.http
@@ -138,7 +138,9 @@ content-type: application/json
 
 ###
 
+GET http://localhost:3000/users/findByUsername/casi HTTP/1.1
 
+###
 
 
 

--- a/backend/srcs/index.js
+++ b/backend/srcs/index.js
@@ -34,8 +34,12 @@ const start = async () => {
       throw new Error("❌ JWT_SECRET is not defined in the environment.");
     }
 
+    const isProduction = process.env.NODE_ENV === "production";
+
     await fastify.register(cors, {
-      origin: true, // according to chatGPT this good for development, but we gotta figure out something else for the final product
+      origin: isProduction
+        ? ["https://transcendance.fi", "https://www.transcendance.fi"]
+        : true, // allow any origin in dev, including REST client and postman etc.
       credentials: true,
       methods: ["GET", "POST", "PUT", "DELETE", "OPTIONS"],
     });

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,8 +5,8 @@ services:
       dockerfile: ./frontend/Dockerfile
     container_name: frontend
     image:  frontend
-    # depends_on:
-    #   - backend
+    depends_on:
+      - backend
     ports:
       - "8443:8443"
     volumes:
@@ -24,7 +24,7 @@ services:
     # depends_on:
     #   - database
     ports:
-      - "3000:3000" #should only be "3000"
+      - "3000" #change to "3000:3000" if you want to access the backend directly
     environment:
       - NODE_ENV=production
     volumes:


### PR DESCRIPTION
This pull request introduces several changes to improve API functionality, production readiness, and container orchestration. The most significant updates include adjustments to CORS settings for production environments, modifications to the Docker Compose configuration, and the addition of a new API endpoint for user lookup.

### API functionality updates:
* [`backend/srcs/APItest/testAPI.http`](diffhunk://#diff-e3c860711f48bc0707bb8348330d3668478962ba417172f36cd59f7e5e5351eeR141-R143): Added a new API endpoint `GET /users/findByUsername/casi` for user lookup by username.

### Production readiness improvements:
* [`backend/srcs/index.js`](diffhunk://#diff-bf32c46c4edcb90f845d4127048f1e7fb6991084d612ca68c9027ce4a663c313R37-R42): Introduced an `isProduction` flag based on `NODE_ENV` and updated CORS settings to restrict origins in production to `https://transcendance.fi` and `https://www.transcendance.fi`, while allowing all origins in development.

### Container orchestration updates:
* [`docker-compose.yml`](diffhunk://#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3L8-R9): Enabled the `depends_on` directive for the `frontend` service to ensure it waits for the `backend` service to start.
* [`docker-compose.yml`](diffhunk://#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3L27-R27): Adjusted the `ports` configuration for the `backend` service to default to `"3000"` but included instructions for changing it to `"3000:3000"` for direct backend access during development.